### PR TITLE
Enable autosectionlabel_prefix_document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,7 @@
 # How to Contribute to our website
 
-Thank you for your offer to help. Here's some instructions for how to contribute. You might want to check in with an admin from the DCC++ EX team before working on documentation changes to identiy current needs.
+Thank you for your offer to help. You might want to check in with an admin from
+the DCC++ EX team before working on documentation changes to identify current needs.
 
-## Submission Procedure
-
-We will assume that you have an appropriate text editor and Git installed on your machine. We recommend the free _Visual Studio Code IDE (VSC)_ and _GitHub Desktop_ or _Git Bash_.
-
-1. Clone the [dcc-ex.github.io](https://github.com/DCC-EX/dcc-ex.github.io/tree/sphinx) repository, to your local machine. Make sure you're on the sphinx branch. ([Cloning a repository in GitHub](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository))
-2. Install _Python 3.8.x_ (which also installs pip) then use pip to install the required packages ```pip install sphinx sphinx_rtd_theme sphinxcontrib-spelling```.
-3. Using Git Bash, go to the "dcc-ex.github.io" folder and make a branch using GitHub desktop or this command: ```git checkout -b your-branch-name```
-4. Open VSC and edit the files in the ```dcc-ex.github.io/docs``` folder. Save, then Preview your changes by running ```make github``` from the root of the ```dcc-ex.github.io``` folder. *This must be done from cmd.exe in windows, not powershell* Then go to the directory ```dcc-ex.github.io/docs/build/html``` and open ```index.html``` in Chrome or another browser. Note that since 11/23/2020, this is just a local preview - when you push your changes GitHub will automatically rebuild your website.
-5. Use ```git add``` and ```git commit -m "MY CHANGE DESCRIPTION"``` often to save changes. If you're using GitHub desktop these are combined in the commit button.
-6. Push it to GitHub: ```git push origin {your-name}-changes```
-8. Go to GitHub and issue a pull request for your branch to be pulled into the sphinx branch. Once it's merged in by one of the admins, your changes will go live!
+See docs/contributing/website.rst for the website standards and tips on how to
+get started.

--- a/docs/about/rewrite.rst
+++ b/docs/about/rewrite.rst
@@ -61,7 +61,7 @@ We completely re-wrote current sense and ACK detect routines to better protect y
 Why did we do this?
 ====================
 
-First and foremost, we just wanted to have fun. We saw an engineering problem and we wanted to tackle it. As is the case with most engineers, we thought we could do it better than anyone else. ;) Second, we saw an opportunity to provide something really amazing to the Model Railroad Community for low cost and that worked as well or better than anything on the market. You can see our :ref:`Mission Statement <Mission>` on the main page.
+First and foremost, we just wanted to have fun. We saw an engineering problem and we wanted to tackle it. As is the case with most engineers, we thought we could do it better than anyone else. ;) Second, we saw an opportunity to provide something really amazing to the Model Railroad Community for low cost and that worked as well or better than anything on the market. You can see our :ref:`Mission Statement <index:Mission>` on the main page.
 
 Details to Make Engineer's Propellers Spin
 ============================================

--- a/docs/advanced-setup/motor-board-config.rst
+++ b/docs/advanced-setup/motor-board-config.rst
@@ -17,13 +17,13 @@ DCC++ EX supports many different motor boards, you can select any of the pre-con
 
 **Links in This Page**
 
-* :ref:`Configure Using the Installer`
-* :ref:`Configure By Editing the config.h File`
-* :ref:`Your Board is in the Supported List`
-* :ref:`Your Board is NOT in the Supported List`
-* :ref:`Using High Accuracy Waveform Mode`
-* :ref:`Current Sense and Sense Factor`
-* :ref:`Just Buy a Current Sense Board Instead`
+* :ref:`advanced-setup/motor-board-config:Configure Using the Installer`
+* :ref:`advanced-setup/motor-board-config:Configure By Editing the config.h File`
+* :ref:`advanced-setup/motor-board-config:Your Board is in the Supported List`
+* :ref:`advanced-setup/motor-board-config:Your Board is NOT in the Supported List`
+* :ref:`advanced-setup/motor-board-config:Using High Accuracy Waveform Mode`
+* :ref:`advanced-setup/motor-board-config:Current Sense and Sense Factor`
+* :ref:`advanced-setup/motor-board-config:Just Buy a Current Sense Board Instead`
 
 Configure Using the Installer
 ==============================

--- a/docs/advanced-setup/supported-microcontrollers/wifi-mega.rst
+++ b/docs/advanced-setup/supported-microcontrollers/wifi-mega.rst
@@ -240,7 +240,7 @@ After flashing, the ESP8266 Log will show it uploaded them all successfully and 
 
 - Disconnect the USB cable.
 
-Skip ahead to :ref:`3. Set the switches for run/sketch mode`
+Skip ahead to :ref:`advanced-setup/supported-microcontrollers/wifi-mega:3. Set the switches for run/sketch mode`
 
 With esptool.py
 ^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ AP Mode (the default) makes the Command Station an Access Point. That is a direc
 
 If you choose to use AP mode, there is nothing you need to do. Just make sure you select the network checkbox in the installer or rename the config.example.h file to config.h and install DCC++EX. Go directly to setp 5.
 
-If you are going to want to connect to your WiFi router, you just need to enter your login information. Take a look at the :ref:`Short Version of Network Setup` below before proceeding to step 5. But keep in mind, you can always install, make changes, and install again.
+If you are going to want to connect to your WiFi router, you just need to enter your login information. Take a look at the :ref:`advanced-setup/supported-microcontrollers/wifi-mega:Short Version of Network Setup` below before proceeding to step 5. But keep in mind, you can always install, make changes, and install again.
 
 
 5. Download and Configure the DCC++EX Command Station Software

--- a/docs/advanced-setup/supported-motorboards/IBT_2-motor-board-setup.rst
+++ b/docs/advanced-setup/supported-motorboards/IBT_2-motor-board-setup.rst
@@ -11,14 +11,14 @@ Engineer Level
 
 |
 
-- :ref:`What You Will Need (IBT_2)`
-- :ref:`Which option should you choose? (IBT_2)`
-- :ref:`Upgrading (Use the Arduino Motor Shield AND the IBT_2)`
-- :ref:`Replacing (Using One IBT_2 for MAIN and another for PROG)`
-- :ref:`Important Notes on Current Sensing (IBT_2)`
-- :ref:`Parts list (IBT_2)`
+- :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:What You Will Need (IBT_2)`
+- :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Which option should you choose? (IBT_2)`
+- :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Upgrading (Use the Arduino Motor Shield AND the IBT_2)`
+- :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Replacing (Using One IBT_2 for MAIN and another for PROG)`
+- :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Important Notes on Current Sensing (IBT_2)`
+- :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Parts list (IBT_2)`
 
-See the :ref:`Parts list (IBT_2)`
+See the :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Parts list (IBT_2)`
 
 .. image:: ../../_static/images/motorboards/ibt_2_bts7960_2.jpg
    :alt: IBT_2 Motor driver
@@ -164,7 +164,7 @@ Change the last line to look like this. To be sure of your spelling, you can cop
 
 Upload the sketch to your arduino. If you need help on how to upload a sketch, see :doc:`Getting Started <../../get-started/index>`
 
-Please see :ref:`Important Notes on Current Sensing (IBT_2)`.
+Please see :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Important Notes on Current Sensing (IBT_2)`.
 
 
 Replacing (Using One IBT_2 for MAIN and another for PROG)
@@ -186,7 +186,7 @@ Steps (Replace)
 ------------------
 The same rules as above apply to using 2 boards. The only difference is that we would use one IBT_2 board for Main and another for PROG. That wiring would look like this:
 
-Please see :ref:`Important Notes on Current Sensing (IBT_2)`.
+Please see :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Important Notes on Current Sensing (IBT_2)`.
 
 TODO: Fritzing image of 2 ibt 2 boards here
 
@@ -331,7 +331,7 @@ Below is the Handson Technology datasheet, recommended reading for Tinkerers and
 ..
 
    TODO: this has to go somewhere:
-   There are two ways to monitor motor board current, one is at the input of the board and the other is at the output. We will cover both of these methods in the :ref:`Important Notes on Current Sensing` section.
+   There are two ways to monitor motor board current, one is at the input of the board and the other is at the output. We will cover both of these methods in the :ref:`advanced-setup/supported-motorboards/IBT_2-motor-board-setup:Important Notes on Current Sensing (IBT_2)` section.
 
    Also, mention "high accuracy mode" and include the circtuit for that.
 

--- a/docs/advanced-setup/supported-motorboards/IRF3205-motor-board-setup.rst
+++ b/docs/advanced-setup/supported-motorboards/IRF3205-motor-board-setup.rst
@@ -11,12 +11,12 @@ Tinkerer Level
 
 |
 
-- :ref:`What You Will Need (IRF3205)`
-- :ref:`Which option should you choose? (IRF3205)`
-- :ref:`Upgrading (Use the Arduino Motor Shield AND the IRF3205)`
-- :ref:`Replacing (Use both IRF3205 outputs to control MAIN and PROG)`
-- :ref:`Important Notes on Current Sensing`
-- :ref:`Parts list (IRF3205)`
+- :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:What You Will Need (IRF3205)`
+- :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Which option should you choose? (IRF3205)`
+- :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Upgrading (Use the Arduino Motor Shield AND the IRF3205)`
+- :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Replacing (Use both IRF3205 outputs to control MAIN and PROG)`
+- :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Important Notes on Current Sensing`
+- :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Parts list (IRF3205)`
 
 What You Will Need (IRF3205)
 =============================
@@ -31,7 +31,7 @@ What You Will Need (IRF3205)
 * A separate current sense board like one based on the ACS724 chip (or just depend on the 5A fuses)
 * Some Jumper Wires
 
-See the :ref:`Parts list (IRF3205)`
+See the :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Parts list (IRF3205)`
 
 .. image:: ../../_static/images/motorboards/15A_Dual_HBridge3.jpg
    :alt: 15A Dual H-Bridge
@@ -68,7 +68,7 @@ The main benefit of the replace option, using only the IRF3205 board, is that yo
 
 To use this option *and* be able to program locos, you **must** have an external current sense board so you can detect the acknowledgement (ACK) pulses from a loco on your programming track. The current sensor also allows the CS to monitor for a short and automatically cut the power to the tracks if there is an overload condition (a short).
 
-There are two ways to monitor motor board current, one is at the input of the board and the other is at the output. We will cover both of these methods in the :ref:`Important Notes on Current Sensing` section.
+There are two ways to monitor motor board current, one is at the input of the board and the other is at the output. We will cover both of these methods in the :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Important Notes on Current Sensing` section.
 
 Upgrading (Use the Arduino Motor Shield AND the IRF3205)
 ===========================================================
@@ -77,7 +77,7 @@ For this installation we are going to assume you already have a working CS or at
 
 If you need instructions on how to install the Arduino Motor Shield, see :doc:`Arduino Motor Shield Assembly <../../get-started/assembly>`
 
-Tinkerers will use their existing motor shield for PROG and replace the MAIN output with one of the outputs of this board. Engineers can skip to :ref:`Replacing (Use both IRF3205 outputs to control MAIN and PROG)` to see how to modify the board so that just the IRF3205 can manage both tracks.
+Tinkerers will use their existing motor shield for PROG and replace the MAIN output with one of the outputs of this board. Engineers can skip to :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Replacing (Use both IRF3205 outputs to control MAIN and PROG)` to see how to modify the board so that just the IRF3205 can manage both tracks.
 
 What Tinkerers Are Going to Do (Upgrade)
 -----------------------------------------
@@ -99,7 +99,7 @@ Steps (Upgrade IRF3205)
 
 3. Move the two wires we just disconnected from the motor shield and connect one to each of the "Motor1" screw terminals of the IRF3205 board. TODO: Add image.
 
-4. NOTE: It is important that the phase of the signal to your PROG and MAIN tracks are the same if you are ever going to use the ``<1 JOIN>`` command to make both tracks a MAIN when the PROG track is not in use, or if you are going to use the "Driveaway" feature. For more detail, see :ref:`Keeping your tracks in phase` below.
+4. NOTE: It is important that the phase of the signal to your PROG and MAIN tracks are the same if you are ever going to use the ``<1 JOIN>`` command to make both tracks a MAIN when the PROG track is not in use, or if you are going to use the "Driveaway" feature. For more detail, see :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Keeping your tracks in phase` below.
 
 5. Use the following diagrams to connect pins from the Arduino Mega to the IRF3205. "CS" in the table means "Current Sense":
 
@@ -117,7 +117,7 @@ Steps (Upgrade IRF3205)
 |     GND      |        GND           |
 +--------------+----------------------+
 
-Here is a visual diagram. See :ref:`Important Notes on Current Sensing`. Click to enlarge:
+Here is a visual diagram. See :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Important Notes on Current Sensing`. Click to enlarge:
 
 .. image:: ../../_static/images/motorboards/IRF3205_w_arduino_fritz.png
    :alt: IRF3205 Wiring Diagram
@@ -169,13 +169,13 @@ This will use pin 3 for Enable and 12 for signal, which will use the "High Accur
 
 8. If you intend to use your Command station for programming on a separate programming track, or you will want to monitor current on your main track, you will connect an external current sense board. See the notes below for more detail about current sense and a suggestion for using an external current sense board.
 
-See :ref:`Important Notes on Current Sensing`
+See :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Important Notes on Current Sensing`
 
 
 Replacing (Use both IRF3205 outputs to control MAIN and PROG)
 ==============================================================
 
-.. NOTE:: This option requires a small external current sense board wired in series with the DC power into the board. This monitors the total current the board uses, so cannot measure the MAIN and PROG tracks separately. You will need to turn off power to MAIN ``<0 MAIN>`` when programming. There is an option to use 2 current sense boards at the output to each track (requires bi-directional current sense boards) or to create a break in the power trace on the board to one of the H-Bridge circuits to monitor DC input current separately. Those options are covered in the :ref:`Tech Notes (IRF3205)` section.
+.. NOTE:: This option requires a small external current sense board wired in series with the DC power into the board. This monitors the total current the board uses, so cannot measure the MAIN and PROG tracks separately. You will need to turn off power to MAIN ``<0 MAIN>`` when programming. There is an option to use 2 current sense boards at the output to each track (requires bi-directional current sense boards) or to create a break in the power trace on the board to one of the H-Bridge circuits to monitor DC input current separately. Those options are covered in the :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Tech Notes (IRF3205)` section.
 
 This section will cover how to the MOTOR1 output to control MAIN and MOTOR2 to control PROG if you do not already have an Arduino Motor Shield or clone. Be careful as the IRF3205 can deliver much more current than you need for a programming track. If you install 1 Amp fuses in between the IRF3205 Motor2 outputs and both rails of your programming track, that and the lower trip current we set in the Command Station for the programming track should protect your layout and your locos.
 
@@ -224,7 +224,7 @@ Use the following diagrams to connect pins from the Arduino Mega to the IRF3205.
 
 It should look like following graphical image. Note we have included the Arduino Mega and have the Arduino Motor shield off to the side for reference. The motor shield would obviously normally be stacked on top of the Arduino. However, some people might not use the motor shield and instead will have another board to use for their programming track. In this case, they would connect the IRF3205 directly to the same pins on the Arduino microcontroller. Please use fuses on BOTH wires of the output to your MAIN track. As with most of our diagrams, you can click on them to enlarge them.
 
-Here is a wiring diagram. See :ref:`Important Notes on Current Sensing` below. Click on images to enlarge them:
+Here is a wiring diagram. See :ref:`advanced-setup/supported-motorboards/IRF3205-motor-board-setup:Important Notes on Current Sensing` below. Click on images to enlarge them:
 
 .. image:: ../../_static/images/motorboards/IRF3205_w_arduino_fritz.png
    :alt: IRF3205 Wiring Diagram

--- a/docs/advanced-setup/wifi-config.rst
+++ b/docs/advanced-setup/wifi-config.rst
@@ -216,16 +216,16 @@ WiFi Config Options
 
 The following defines are all the possible network settings found the config.h file. If you used the automated installer, you may see a few of these already listed. If you do a manual Arduino IDE install, you will see all of these in the file you renamed from "config.example.h" to "config.h".
 
-| :ref:`#define IP_PORT 2560`
-| :ref:`#define ENABLE_WIFI true`
-| :ref:`#define DONT_TOUCH_WIFI_CONF`
-| :ref:`#define WIFI_SSID "Your network name"`
-| :ref:`#define WIFI_PASSWORD "Your network passwd"`
-| :ref:`#define WIFI_HOSTNAME "dccex"`
-| :ref:`#define WIFI_CONNECT_TIMEOUT 14000`
-| :ref:`#define ENABLE_ETHERNET true`
-| :ref:`#define IP_ADDRESS { 192, 168, 1, 200 }`
-| :ref:`#define MAC_ADDRESS {  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xEF }`
+| :ref:`advanced-setup/wifi-config:#define IP_PORT 2560`
+| :ref:`advanced-setup/wifi-config:#define ENABLE_WIFI true`
+| :ref:`advanced-setup/wifi-config:#define DONT_TOUCH_WIFI_CONF`
+| :ref:`advanced-setup/wifi-config:#define WIFI_SSID "Your network name"`
+| :ref:`advanced-setup/wifi-config:#define WIFI_PASSWORD "Your network passwd"`
+| :ref:`advanced-setup/wifi-config:#define WIFI_HOSTNAME "dccex"`
+| :ref:`advanced-setup/wifi-config:#define WIFI_CONNECT_TIMEOUT 14000`
+| :ref:`advanced-setup/wifi-config:#define ENABLE_ETHERNET true`
+| :ref:`advanced-setup/wifi-config:#define IP_ADDRESS { 192, 168, 1, 200 }`
+| :ref:`advanced-setup/wifi-config:#define MAC_ADDRESS {  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xEF }`
 
 #define IP_PORT 2560
 --------------------

--- a/docs/automation/EX-RAIL-intro.rst
+++ b/docs/automation/EX-RAIL-intro.rst
@@ -72,7 +72,7 @@ The Automation Process
 
 All routes, automations, etc step through a list of simple keywords until they reach a ``DONE`` keyword. 
 
-For a full list of keywords, see :ref:`EX-RAIL Command Summary`.
+For a full list of keywords, see :doc:`EX-RAIL-ref`.
 
 Automation scripts are added to your Command Station by creating a file called "myAutomation.h" in the same folder as CommandStation-EX.ino, and adding in the scripts as follows:
 
@@ -192,7 +192,7 @@ Turnouts defined in 'myAutomation.h' will still be visible to WiThrottle and JMR
 
 A TURNOUT sends DCC signals to a decoder attached to the track, a PIN_TURNOUT sends a "throw" or "close" (5V or 0V signal) to a pin on the Arduino, and a SERVO_TURNOUT sends an I2C serial command to a servo board connected to your servos.
  
-See the :ref:`Reference<EX-RAIL Command Summary>` section for TURNOUT, PIN_TURNOUT and SERVO_TURNOUT definitions.
+See the :doc:`Reference <EX-RAIL-ref>` page for TURNOUT, PIN_TURNOUT and SERVO_TURNOUT definitions.
 
 
 Defining Signals
@@ -336,7 +336,7 @@ number. So now our route looks like this:
    :align: center
    :scale: 100%
 
-Assuming that you have defined your turnouts with :ref:`TURNOUT commands.<Routes, Automations, and Sequences>`
+Assuming that you have defined your turnouts with :ref:`TURNOUT commands. <automation/EX-RAIL-ref:Routes, Automations, and Sequences>`
 
 .. code-block:: cpp
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,8 +49,6 @@ spelling_lang='en_US'
 tokenizer_lang='en_US'
 spelling_word_list_filename = ['spelling_wordlist.txt']
 
-suppress_warnings = ['autosectionlabel.*']
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,8 @@ extensions = [
     'sphinxcontrib.spelling',
 ]
 
+autosectionlabel_prefix_document = True
+
 spelling_lang='en_US'
 tokenizer_lang='en_US'
 spelling_word_list_filename = ['spelling_wordlist.txt']

--- a/docs/contributing/website.rst
+++ b/docs/contributing/website.rst
@@ -26,6 +26,11 @@ We will assume that you have an appropriate text editor and Git installed on you
 Standards
 ==========
 
+.. highlight:: rst
+
+Headings
+--------
+
 * Main Headings have asterisks above and below them
 * Subheadings are underlined with equals signs
 * The next level is underlined with underscores
@@ -33,5 +38,91 @@ Standards
 * The last one we use is underlined with tildes
 
 All heading underlines and overlines must be at least as long as the text of the heading
+
+Links
+-----
+
+Internal
+^^^^^^^^
+
+Sphinx cross-references are used for internal links. This ensures they are
+correct and by default will use the destination heading text as the link text.
+
+To link to a page use ``:doc:``:
+
+.. admonition:: Example
+
+    ::
+
+        :doc:`/reference/hardware/motor-boards`
+
+    :doc:`/reference/hardware/motor-boards`
+
+The document name is a relative or absolute (within the documentation) file
+path, without the .rst suffix.
+
+To link to a position within a page use ``:ref:``. A reST label can be used as
+the reference, but on the DCC++EX website headings are made available to use as
+references:
+
+.. admonition:: Example
+
+    ::
+
+        :ref:`advanced-setup/motor-board-config:Configure Using the Installer`
+
+    :ref:`advanced-setup/motor-board-config:Configure Using the Installer`
+
+The reference is the full name of the document (the absolute path without
+a leading /), a colon, and the section heading. The full name must be used
+even when referring to headings in the same source file.
+
+Alternative text can be used for the link:
+
+.. admonition:: Example
+
+    ::
+
+        :ref:`WiFi configuration <advanced-setup/supported-microcontrollers/wifi-mega:Short Version of Network Setup>`
+
+    :ref:`WiFi configuration <advanced-setup/supported-microcontrollers/wifi-mega:Short Version of Network Setup>`
+
+External
+^^^^^^^^
+
+For URLs that are shown, just use the URL:
+
+.. admonition:: Example
+
+    ::
+
+        https://dcc-ex.com/index.html
+
+    https://dcc-ex.com/index.html
+
+To show link text instead of the URL:
+
+.. admonition:: Example
+
+    ::
+
+        `Trainboard Thread <https://www.trainboard.com/highball/index.php?threads/dcc-voltage-and-n-scale-locomotives.56342/>`_
+
+    `Trainboard Thread <https://www.trainboard.com/highball/index.php?threads/dcc-voltage-and-n-scale-locomotives.56342/>`_
+
+For better accessibility, and generally clearer content, use `strong link text <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#accessibility>`_.
+
+If the link will be used multiple times, or to keep the URL separate in the
+source file, define a target:
+
+.. admonition:: Example
+
+    ::
+
+        Link to the `DCC++EX home page`_.
+
+        .. _DCC++EX home page: https://dcc-ex.com/index.html
+
+    Link to the `DCC++EX home page <https://dcc-ex.com/index.html>`_.
 
 *Work in progress*

--- a/docs/download/commandstation.rst
+++ b/docs/download/commandstation.rst
@@ -4,16 +4,16 @@ Command Station Downloads
 
 Welcome to the Command Station download page. You have several choices:
 
-* **[RECOMMENDED]** If you are a Conductor, or you just want an easy installer to do the work for you, go to the :ref:`exInstaller` section. 
-* If you are a Tinkerer, or you would like to download a zip file and install the firmware using the Arduino IDE, go to the :ref:`Latest DCC++ EX Official Release` section.
-* To get the latest unreleased development version, go to the :ref:`Latest DCC++ EX Unreleased Development Version`, including the excitement of **EX-RAIL Automation**!
-* If you are an Engineer or developer, and want to clone the repository onto your computer, go to the :ref:`CommandStation-EX Repository (project source files)` section.
-* If you're still looking for BaseStation-Classic, go to the :ref:`Getting BaseStation-Classic` section.
+* **[RECOMMENDED]** If you are a Conductor, or you just want an easy installer to do the work for you, go to the :ref:`download/commandstation:exInstaller` section.
+* If you are a Tinkerer, or you would like to download a zip file and install the firmware using the Arduino IDE, go to the :ref:`download/commandstation:Latest DCC++ EX Official Release` section.
+* To get the latest unreleased development version, go to the :ref:`download/commandstation:Latest DCC++ EX Unreleased Development Version`, including the excitement of **EX-RAIL Automation**!
+* If you are an Engineer or developer, and want to clone the repository onto your computer, go to the :ref:`download/commandstation:CommandStation-EX Repository (project source files)` section.
+* If you're still looking for BaseStation-Classic, go to the :ref:`download/commandstation:Getting BaseStation-Classic` section.
 
 exInstaller
 =============
 
-.. note:: Clicking on the link below will automatically find the correct version for your Computer and Operating system (Windows, Mac, Linux) and download it. After unzipping the files to a folder on your computer and running the "exInstaller" program, you will have the opportunity to select either CommandStation-EX or BaseStation-Classic, and options, such as your Arduino type and motor shield type. It will automatically upload the software to your Arduino or other supported board. Click here for :doc:`exInstaller installation instructions <../get-started/installer>`. If you have an issue with the web page getting you the correct version, click on the :ref:`Latest DCC++ EX Official Release` button in the next section to manually download the correct version.
+.. note:: Clicking on the link below will automatically find the correct version for your Computer and Operating system (Windows, Mac, Linux) and download it. After unzipping the files to a folder on your computer and running the "exInstaller" program, you will have the opportunity to select either CommandStation-EX or BaseStation-Classic, and options, such as your Arduino type and motor shield type. It will automatically upload the software to your Arduino or other supported board. Click here for :doc:`exInstaller installation instructions <../get-started/installer>`. If you have an issue with the web page getting you the correct version, click on the :ref:`download/commandstation:Latest DCC++ EX Official Release` button in the next section to manually download the correct version.
 
 .. raw:: html 
 

--- a/docs/get-started/wifi-setup.rst
+++ b/docs/get-started/wifi-setup.rst
@@ -55,9 +55,9 @@ What you will need (for WiFi)
 Quick links
 ==============
 
-* Jump to :ref:`Makerfabs ESP8266 WiFi Shield (recommended)`
-* Jump to :ref:`Duinopeak ESP8266 WiFi Expansion Board`
-* Jump to :ref:`ESP-01 and ESP-01s`
+* Jump to :ref:`get-started/wifi-setup:Makerfabs ESP8266 WiFi Shield (recommended)`
+* Jump to :ref:`get-started/wifi-setup:Duinopeak ESP8266 WiFi Expansion Board`
+* Jump to :ref:`get-started/wifi-setup:ESP-01 and ESP-01s`
 
 Makerfabs ESP8266 WiFi Shield (recommended)
 ===============================================

--- a/docs/reference/hardware/ethernet-boards.rst
+++ b/docs/reference/hardware/ethernet-boards.rst
@@ -13,10 +13,10 @@ To use Ethernet instead of WiFi, follow these simple steps:
 * Enter the SSID for your router by replacing "Your network name" with the name of your network in ``#define WIFI_SSID "Your network name"`` in between the quotes.
 * Enter the Password for your router by replacing "Your network passwd" with your password in the line:``#define WIFI_PASSWORD "Your network passwd"`` in between the quotes.
 
-* :ref:`Arduino Network Shield 2` **[RECOMMENDED]**
-* :ref:`Wiznet WIZ850IO`
-* :ref:`Sunfounder Ethernet Shield`
-* :ref:`Nano Ethernet Shield`
+* :ref:`reference/hardware/ethernet-boards:Arduino Network Shield 2` **[RECOMMENDED]**
+* :ref:`reference/hardware/ethernet-boards:Wiznet WIZ850IO`
+* :ref:`reference/hardware/ethernet-boards:Sunfounder Ethernet Shield`
+* :ref:`reference/hardware/ethernet-boards:Nano Ethernet Shield`
 
 
 Arduino Network Shield 2

--- a/docs/reference/hardware/microcontroller-boards.rst
+++ b/docs/reference/hardware/microcontroller-boards.rst
@@ -4,12 +4,12 @@ Microcontroller Boards
 
 CommandStation-EX currently is designed for Arduino and select microcontollers. Out of the box, it is compatible with the following boards:
 
-* :ref:`Arduino Mega` **[RECOMMENDED]**
-* :ref:`Mega+Wifi` (Tinkerer Level)
-* :ref:`Arduino Uno`
-* :ref:`Arduino Nano` (Tinkerer Level)
-* :ref:`Nano Every` (Tinkerer Level)
-* :ref:`Teensy 3.x & 4.x` (Engineer Level)
+* :ref:`reference/hardware/microcontroller-boards:Arduino Mega` **[RECOMMENDED]**
+* :ref:`reference/hardware/microcontroller-boards:Mega+Wifi` (Tinkerer Level)
+* :ref:`reference/hardware/microcontroller-boards:Arduino Uno`
+* :ref:`reference/hardware/microcontroller-boards:Arduino Nano` (Tinkerer Level)
+* :ref:`reference/hardware/microcontroller-boards:Nano Every` (Tinkerer Level)
+* :ref:`reference/hardware/microcontroller-boards:Teensy 3.x & 4.x` (Engineer Level)
 
 Arduino Mega
 ===============================

--- a/docs/reference/hardware/motor-boards.rst
+++ b/docs/reference/hardware/motor-boards.rst
@@ -24,32 +24,32 @@ Boards currently supported
 
   **Easy to use boards**
 
-   * :ref:`Arduino Motor Shield` - 2A rated, 1.5 possible **[RECOMMENDED]**
-   * :ref:`Deek-Robot Motor Shield` - 2A rated, 1.5 possible **[RECOMMENDED]**
-   * :ref:`Flashtree Motor Shield` - 2A rated, 1.5 possible
-   * :ref:`DIY More L298NH Motor Shield` - 2A
-   * :ref:`YFRobot L298P Motor Shield` - 2A
-   * :ref:`Pololu MC33926` - 3A - current sensing is not appropriate for most CV programming
+   * :ref:`reference/hardware/motor-boards:Arduino Motor Shield` - 2A rated, 1.5 possible **[RECOMMENDED]**
+   * :ref:`reference/hardware/motor-boards:Deek-Robot Motor Shield` - 2A rated, 1.5 possible **[RECOMMENDED]**
+   * :ref:`reference/hardware/motor-boards:Flashtree Motor Shield` - 2A rated, 1.5 possible
+   * :ref:`reference/hardware/motor-boards:DIY More L298NH Motor Shield` - 2A
+   * :ref:`reference/hardware/motor-boards:YFRobot L298P Motor Shield` - 2A
+   * :ref:`reference/hardware/motor-boards:Pololu MC33926` - 3A - current sensing is not appropriate for most CV programming
 
   **Intermediate boards (Tinkerer Level)** - require wiring
 
-   * :ref:`L298N Motor Driver (dual)` - 2A
-   * :ref:`MiniIBT Motor Driver L6201P (single)` - 5A
-   * :ref:`Makerfabs H-Bridge Motor Shield` - 8A
-   * :ref:`BTS7960 IBT_2 Board (single)` - 43A
-   * :ref:`Dual Motor Driver Module H-bridge MOSFET IRF3205` - 15A
+   * :ref:`reference/hardware/motor-boards:L298N Motor Driver (dual)` - 2A
+   * :ref:`reference/hardware/motor-boards:MiniIBT Motor Driver L6201P (single)` - 5A
+   * :ref:`reference/hardware/motor-boards:Makerfabs H-Bridge Motor Shield` - 8A
+   * :ref:`reference/hardware/motor-boards:BTS7960 IBT_2 Board (single)` - 43A
+   * :ref:`reference/hardware/motor-boards:Dual Motor Driver Module H-bridge MOSFET IRF3205` - 15A
 
   **Expert Level Boards (Tinkerer or Engineer Level)** - these boards require you to add your own config to the config.h file, and may not have good current sensing. That said, if you buy a separate current sense board, we particularly like the IBT_2 board (though you will need 2 of them or some other board for the programming track)
   
-   * :ref:`Keyes/Fundumoto ("Beeper Board")` - 2A
-   * :ref:`Velleman KA03 (kit) VMA03 (soldered)` - 2A
-   * :ref:`DFRobot 2x2A DC Motor Shield (DRI0009)` - 2A
+   * :ref:`reference/hardware/motor-boards:Keyes/Fundumoto ("Beeper Board")` - 2A
+   * :ref:`reference/hardware/motor-boards:Velleman KA03 (kit) VMA03 (soldered)` - 2A
+   * :ref:`reference/hardware/motor-boards:DFRobot 2x2A DC Motor Shield (DRI0009)` - 2A
 
   **Non-compatible boards**
 
    * VNH2SP30 - Sparkfun Monster Moto and others. It can't switch fast enough to generate a reliable DCC signal
    * IFX9202ED - Infineon Dual H-Bridge. Can't switch fast enough.
-   * :ref:`Dfrobot Romeo V2` - Well, an Engineer could perhaps get this one to work.
+   * :ref:`reference/hardware/motor-boards:Dfrobot Romeo V2` - Well, an Engineer could perhaps get this one to work.
    * Kuman Board (and any L293D based boards) - not enough current.
    
 Other boards, while not fully supported and tested, can be used. Look for the following criteria:

--- a/docs/reference/hardware/power-supplies.rst
+++ b/docs/reference/hardware/power-supplies.rst
@@ -6,22 +6,22 @@ The power supply is one of the most important parts of your setup. You need to s
 
 **What's covered here:**
 
-* :ref:`Do I need two power supplies?`
-* :ref:`Four ways to power the Arduino`
-* :ref:`Powering the Motor Controller`
-* :ref:`Wall Warts`
-* :ref:`Bricks (Laptop Style)`
-* :ref:`Adjustable Power Supplies`
-* :ref:`Cage Power Supplies`
-* :ref:`Dual voltage power supplies`
-* :ref:`Using one power supply with cheap converters to power everything`
-* :ref:`Using Buck Converters`
+* :ref:`reference/hardware/power-supplies:Do I need two power supplies?`
+* :ref:`reference/hardware/power-supplies:Four ways to power the Arduino`
+* :ref:`reference/hardware/power-supplies:Powering the Motor Controller`
+* :ref:`reference/hardware/power-supplies:Wall Warts`
+* :ref:`reference/hardware/power-supplies:Bricks (Laptop Style)`
+* :ref:`reference/hardware/power-supplies:Adjustable Power Supplies`
+* :ref:`reference/hardware/power-supplies:Cage Power Supplies`
+* :ref:`reference/hardware/power-supplies:Dual voltage power supplies`
+* :ref:`reference/hardware/power-supplies:Using one power supply with cheap converters to power everything`
+* :ref:`reference/hardware/power-supplies:Using Buck Converters`
 
 
 Do I need two power supplies?
 ==============================
 
-Well, you at least need two voltages. It is possible to get multiple voltages from one power supply, how to do that is covered below in the :ref:`Using one power supply with cheap converters to power everything`. Both your microcontroller (the Arduino) and the motor controller need power. While we recommend a 7-9 Volt, 1 Amp, DC power supply for an Arduino Uno or Mega, there are other ways to power it. The voltage requirement to the motor controller does not change based on how you power your Arduino, you need the correct voltage and amperage for your guage and layout.
+Well, you at least need two voltages. It is possible to get multiple voltages from one power supply, how to do that is covered below in the :ref:`reference/hardware/power-supplies:Using one power supply with cheap converters to power everything`. Both your microcontroller (the Arduino) and the motor controller need power. While we recommend a 7-9 Volt, 1 Amp, DC power supply for an Arduino Uno or Mega, there are other ways to power it. The voltage requirement to the motor controller does not change based on how you power your Arduino, you need the correct voltage and amperage for your guage and layout.
 
 Four ways to power the Arduino
 ----------------------------------

--- a/docs/reference/hardware/shopping-list.rst
+++ b/docs/reference/hardware/shopping-list.rst
@@ -4,8 +4,8 @@ Shopping List
 
 .. NOTE:: There are many sources and sometimes different names for Mega and Motor Shield clones. Please see the Microcontroller Boards and Motor Boards page for info on specific motor boards and links of where to find them.
 
-:ref:`Motor Boards`
-:ref:`Microcontroller Boards`
+:doc:`/reference/hardware/motor-boards`
+:doc:`/reference/hardware/microcontroller-boards`
 
 CS Hardware
 ============

--- a/docs/reference/hardware/wifi-boards.rst
+++ b/docs/reference/hardware/wifi-boards.rst
@@ -6,13 +6,13 @@ You can connect up to 5 WiFi throttles. For the standard Mega board, we recommen
 
 For more information on how to configure your CS to use the boards below, see :doc:`Wifi Setup <../../get-started/wifi-setup>`
 
-- :ref:`Makerfabs WiFi Shield`.
-- :ref:`Duinopeak WiFi Shield`.
-- :ref:`ESP-01S`.
-- :ref:`WangTongze Board`.
-- :ref:`Mega+WiFi Configuration`. (this link will take you to another page)
-- :ref:`Sparkfun Thing Plus (ESP32)`.
-- :ref:`ESP32_Ant-01 Breakout and Development Board (ESP32)`.
+- :ref:`reference/hardware/wifi-boards:Makerfabs WiFi Shield`.
+- :ref:`reference/hardware/wifi-boards:Duinopeak WiFi Shield`.
+- :ref:`reference/hardware/wifi-boards:ESP-01S`.
+- :ref:`reference/hardware/wifi-boards:WangTongze Board`.
+- :doc:`Mega+WiFi </advanced-setup/supported-microcontrollers/wifi-mega>`. (this link will take you to another page)
+- :ref:`reference/hardware/wifi-boards:Sparkfun Thing Plus (ESP32)`.
+- :ref:`reference/hardware/wifi-boards:ESP32_Ant-01 Breakout and Development Board (ESP32)`.
 
 .. NOTE:: This is NOT to make a connection to JMRI. Use a USB cable instead. The WiFi and Ethernet solutions are designed to allow throttles to connect directly to the DCC-EX CS without the need for any other software such as JMRI. While using a WiFi/Ethernet connection to JMRI will work, the overhead required internally will slow performance, take up valuable system memory, and prevent broadcast messages for sensors and power state.
 

--- a/docs/reference/software/diagnostic-d-ack-command.rst
+++ b/docs/reference/software/diagnostic-d-ack-command.rst
@@ -2,11 +2,11 @@
 Diagnostics ``<D ACK>`` Command
 ********************************
 
-- :ref:`<D ACK ON>` - Turn on Loco acknowledgement diagnostics
-- :ref:`<D ACK LIMIT mA>` - Override ACK processing mA pulse size
-- :ref:`<D ACK MIN µS>` - Override ACK processing minimum pulse width
-- :ref:`<D ACK MAX µS>` - Override ACK processing max pulse width
-- :ref:`<D PROGBOOST>` - Override 250mA prog track limit while idle.
+- :ref:`reference/software/diagnostic-d-ack-command:\<D ACK ON\>` - Turn on Loco acknowledgement diagnostics
+- :ref:`reference/software/diagnostic-d-ack-command:\<D ACK LIMIT mA\>` - Override ACK processing mA pulse size
+- :ref:`reference/software/diagnostic-d-ack-command:\<D ACK MIN µS\>` - Override ACK processing minimum pulse width
+- :ref:`reference/software/diagnostic-d-ack-command:\<D ACK MAX µS\>` - Override ACK processing max pulse width
+- :ref:`reference/software/diagnostic-d-ack-command:\<D PROGBOOST\>` - Override 250mA prog track limit while idle.
 
 <D ACK ON>
 ============

--- a/docs/reference/software/hal-config.rst
+++ b/docs/reference/software/hal-config.rst
@@ -219,7 +219,7 @@ This will need to be done in the :doc:`Arduino-IDE <../../get-started/arduino-id
 Create a new tab
 ----------------
 
-First you will need to add a new file, just like the :ref:`config.h file <Copy the config.example.h file (or rename it)>`.
+First you will need to add a new file, just like the :ref:`config.h file <get-started/arduino-ide:Copy the config.example.h file (or rename it)>`.
 Create a new tab using the following menu option.
 
 .. image:: ../../_static/images/arduino-ide/arduino_ide_newtab.jpg
@@ -301,7 +301,7 @@ The file contents should now look like:
 Upload the new version of the software
 --------------------------------------
 
-Finally, upload the code to the Arduino as you would do during the standard :ref:`Arduino IDE Setup <Upload the software>`.
+Finally, upload the code to the Arduino as you would do during the standard :ref:`Arduino IDE Setup <get-started/arduino-ide:Upload the software>`.
 Restart the Command Station and the new device will be configured at startup.  
 
 Checking the Driver

--- a/docs/reference/tools/diagnostic-tools.rst
+++ b/docs/reference/tools/diagnostic-tools.rst
@@ -8,10 +8,10 @@ DCC Diagnostic Tools
 
 There are many tools to help you operate your layout and find issues with your trains and accessories. We will list some of the most helpful tools here including where to buy them assembled or how to build them yourself.
 
-* :ref:`Sniffer vs. Analyzer`
-* :ref:`DCC Sniffer (packet analyzer)`
-* :ref:`Logic Analyzer/Decoder`
-* :ref:`DCC Track Phase Detector`
+* :ref:`reference/tools/diagnostic-tools:Sniffer vs. Analyzer`
+* :ref:`reference/tools/diagnostic-tools:DCC Sniffer (packet analyzer)`
+* :ref:`reference/tools/diagnostic-tools:Logic Analyzer/Decoder`
+* :ref:`reference/tools/diagnostic-tools:DCC Track Phase Detector`
  
 
 Sniffer vs. Analyzer


### PR DESCRIPTION
Expected to fail the check because only one :ref: is converted to autosectionlabel_prefix_document format. Just an illustration for now. I will add to this (replacing the WIP commit).

Closes: #100.
