### PR TITLE
Allow build job to be triggered manually

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,8 @@ on:
     branches: [ sphinx ]
   pull_request:
     branches: [ sphinx ]
-  
+  workflow_dispatch:
+
 jobs:
   build:
 


### PR DESCRIPTION
This enables running the workflow from the actions page without having to wait for a merge.

This is needed now to fix the missing images #106 after #108 is merged. Although in this case just merging this PR will have that effect. So, it's a no effect way of doing that.