### PR TITLE
Use Ubuntu for build instead of macOS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,10 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Requirements
-      run: brew install sphinx-doc
-        && brew install enchant
-        && pip3 install sphinx-rtd-theme==0.5.2
+      run: pip3 install sphinx-rtd-theme==0.5.2
         && pip3 install sphinx-sitemap
         && pip3 install sphinxcontrib-spelling
     - name: Checkout repo

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: Docs
 
 on:
-  #push:
-  #  branches-ignore:
-  #    - '**'  
   push:
     branches: [ sphinx ]
   pull_request:
@@ -12,25 +9,24 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     steps:
-    - name: Requirements
-      run: |
-        pip3 install sphinx-rtd-theme==0.5.2
-        pip3 install sphinx-sitemap
-        pip3 install sphinxcontrib-spelling
-    - name: Checkout repo
-      uses: actions/checkout@1.0.0
-    - name: Build docs
-      run: |
-        make github
-        echo 'dcc-ex.com' > docs/_build/html/CNAME
-        touch docs/_build/html/.nojekyll        
-    - name: Deploy
-      if: github.ref == 'refs/heads/sphinx'
-      uses: JamesIves/github-pages-deploy-action@releases/v3
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: docs/_build/html # The folder the action should deploy.
+      - name: Requirements
+        run: |
+          pip3 install sphinx-rtd-theme==0.5.2
+          pip3 install sphinx-sitemap
+          pip3 install sphinxcontrib-spelling
+      - name: Checkout repo
+        uses: actions/checkout@1.0.0
+      - name: Build docs
+        run: |
+          make github
+          echo 'dcc-ex.com' > docs/_build/html/CNAME
+          touch docs/_build/html/.nojekyll
+      - name: Deploy
+        if: github.ref == 'refs/heads/sphinx'
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages  # The branch the action should deploy to.
+          FOLDER: docs/_build/html  # The folder the action should deploy.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,15 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Requirements
-      run: pip3 install sphinx-rtd-theme==0.5.2
-        && pip3 install sphinx-sitemap
-        && pip3 install sphinxcontrib-spelling
+      run: |
+        pip3 install sphinx-rtd-theme==0.5.2
+        pip3 install sphinx-sitemap
+        pip3 install sphinxcontrib-spelling
     - name: Checkout repo
       uses: actions/checkout@1.0.0
     - name: Build docs
-      run:  make github
-        && echo 'dcc-ex.com' > docs/_build/html/CNAME
-        && touch docs/_build/html/.nojekyll        
+      run: |
+        make github
+        echo 'dcc-ex.com' > docs/_build/html/CNAME
+        touch docs/_build/html/.nojekyll        
     - name: Deploy
       if: github.ref == 'refs/heads/sphinx'
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  brackets: disable
+  document-start: disable
+  line-length: disable
+  truthy: {check-keys: false}


### PR DESCRIPTION
Using Sphinx on the case-insensitive macOS filesystem led to #106 when the difference in capitalisation between the image directive and the image filename was resolved.

Also tidy the build.yml file and make future checking with yamllint straightforward.
