### PR TITLE
Fix broken links in references

### DIFF
--- a/docs/reference/hardware/power-supplies.rst
+++ b/docs/reference/hardware/power-supplies.rst
@@ -44,7 +44,7 @@ Powering the Motor Controller
 Voltage
 ^^^^^^^^^
 
-N and Z scale layouts should run at at about 12V-14V to avoid damage to the motors. See this thread to learn more about the pros and cons of running at higher voltages at this `Trainboard Thread <https://www.trainboard.com/highball/index.php?threads/dcc-voltage-and-n-scale-locomotives.56342/>`_ Another good link (along with just about anything written by Mark Gurries), is here: `Mark Gurries - Choosing the Right Booster <https://sites.google.com/site/markgurries/home/technical-discussions/boosters/choosing-the-right-booster>`_
+N and Z scale layouts should run at at about 12V-14V to avoid damage to the motors. See this thread to learn more about the pros and cons of running at higher voltages at this `Trainboard Thread <https://www.trainboard.com/highball/index.php?threads/dcc-voltage-and-n-scale-locomotives.56342/>`_ Another good link (along with just about anything written by Mark Gurries), is here: `Mark Gurries - Choosing the Right Booster <https://sites.google.com/site/markgurries/dcc-welcome-page/advanced-topics/boosters/choosing-the-right-booster>`_
 
 Most larger scales will run higher voltages. For reference, Digitrax systems put the rails at around 14V and garden scale could be 18V. Do some homework to determine what voltage is best for your system.
 

--- a/docs/reference/software/diagnostic-d-command.rst
+++ b/docs/reference/software/diagnostic-d-command.rst
@@ -21,7 +21,7 @@ Speed Step Configuation
 The following commands turn ON(1) or OFF(0) various diagnostic traces
 ======================================================================
 
-``<D ACK ON|OFF>:doc:`` trace DCC ACK processing when reading/writing on the prog track. See `Diagnostics D ACK Command <diagnostic-d-ack-command>`
+``<D ACK ON|OFF>`` trace DCC ACK processing when reading/writing on the prog track. See :doc:`diagnostic-d-ack-command`.
 
 ``<D CMD ON|OFF>`` trace received JMRI commands.
 


### PR DESCRIPTION
External link from Power Supplies to Mark Gurries' site has moved.

Internal link from Diagnostics <D> Command to Diagnostics D ACK Command
was not converted correctly in:
7841f9b ("Fix links and warnings (#88)", 2022-01-12)