### PR TITLE
Fix typos in DCC++ EX and EX-RAIL documentation

### DIFF
--- a/docs/automation/EX-RAIL-intro.rst
+++ b/docs/automation/EX-RAIL-intro.rst
@@ -312,7 +312,7 @@ When the Command Station is powered up or reset, EX-RAIL starts operating at the
 
 .. code-block:: cpp
 
-   SENDLOCO(3,13) // Start sequence 12 using loco 3
+   SENDLOCO(3,13) // Start sequence 13 using loco 3
    DONE           // This marks the end of the startup process
 
 The sequence can also be started from a serial monitor with the command ``</ START 3 13>``.

--- a/docs/automation/EX-RAIL-summary.rst
+++ b/docs/automation/EX-RAIL-summary.rst
@@ -97,7 +97,7 @@ There are some diagnostic and control commands added to the <tag> language norma
       </tr>
       <tr>
         <td class="fitwidth"> &lt;/ KILL task_id&gt;</td>
-        <td>Kills a currently running script task by ID (use </ > to list task IDs)</td>
+        <td>Kills a currently running script task by ID (use &lt;/&gt; to list task IDs)</td>
       </tr>
       <tr>
         <td class="fitwidth"> &lt;/ RESERVE block_id&gt;</td>

--- a/docs/reference/software/command-reference.rst
+++ b/docs/reference/software/command-reference.rst
@@ -179,7 +179,7 @@ Breakdown for this example ``<t 1 03 20 1>`` is:
    "1" = register 1 was changed
    "20" = set to speed 20
    "1" = forward direction
-   "<" = End DCC++ EX command
+   ">" = End DCC++ EX command
 
 **Forget Locos**
 

--- a/docs/reference/software/command-reference.rst
+++ b/docs/reference/software/command-reference.rst
@@ -473,7 +473,7 @@ Turnouts may be in either of two states:  Closed or Thrown.  The turnout command
   * Before Version 3.2.0: Returns: ``<H ID ADDRESS SUBADDRESS THROWN>`` for each defined DCC Accessory Turnout or ``<X>`` if no turnouts have beed defined or saved.  
   * After Version 3.2.0: Returns the parameters that would be used to create the turnout, with the ``THROWN`` state (1=thrown, 0=closed) appended.  For example, 
     a servo turnout definition will be listed as ``<H ID SERVO PIN THROWNPOSITION CLOSEDPOSITION PROFILE THROWN>`` and a DCC turnout
-    will be listed as ``<H ID DCC ADDRESS SUBADDRESS THROWN>``, a VPIN turnout as ``<H ID VPIN PIN THROWN> and an LCN turnout as ``<H ID LCN THROWN>``.
+    will be listed as ``<H ID DCC ADDRESS SUBADDRESS THROWN>``, a VPIN turnout as ``<H ID VPIN PIN THROWN>`` and an LCN turnout as ``<H ID LCN THROWN>``.
 
 * ``ID`` : The numeric ID (0-32767) of the turnout to control.  
 


### PR DESCRIPTION
I think these are fairly simple but possibly worth a review.