### PR TITLE
Use reST links for downloads

### DIFF
--- a/docs/_static/css/dccex_theme.css
+++ b/docs/_static/css/dccex_theme.css
@@ -16,7 +16,7 @@
     margin: 5% 15%;
 }
 
-.dcclink {
+.dcclink a {
   background-color: lightseagreen;
   box-shadow: 0 2px 0 darkslategray;
   color: white;
@@ -27,16 +27,16 @@
   border-radius: 5px;
 }
 
-.dcclink:visited {
-    color: whitesmoke
+.dcclink a:visited {
+  color: whitesmoke
 }
 
-.dcclink:hover {
+.dcclink a:hover {
   background-color: darkslategrey;
   cursor: pointer;
 }
 
-.dcclink:active {
+.dcclink a:active {
   box-shadow: none;
   top: 5px;
 }

--- a/docs/advanced-setup/supported-microcontrollers/wifi-mega.rst
+++ b/docs/advanced-setup/supported-microcontrollers/wifi-mega.rst
@@ -86,23 +86,22 @@ Using the Flash Download Tool (Windows)
 
 Download the Flash Download Tool and the ESP8266_NONOS_AT_Bin_v1.7.4 firmware files by clicking on the buttons below. Unzip them wherever you like:
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="../../_static/files/esp8266/flash_download_tool_v3.8.5.zip">Flash Download tool</a></p>
+   `Flash Download tool </_static/files/esp8266/flash_download_tool_v3.8.5.zip>`_
   
-
-.. raw:: html
+.. rst-class:: dcclink
   
-   <p><a class="dcclink" href="../../_static/files/esp8266/ESP8266_NonOS_AT_Bin_V1.7.4.zip">ESP8266 Firmware Zipped</a></p>
+   `ESP8266 Firmware Zipped </_static/files/esp8266/ESP8266_NonOS_AT_Bin_V1.7.4.zip>`_
 
 Using esptool.py (Windows, Mac, Linux)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Download the ESP8266_NONOS_AT_BIN_v1.7.4 firmware files by clicking the button below:
 
-.. raw:: html
+.. rst-class:: dcclink
    
-   <p><a class="dcclink" href="../../_static/files/esp8266/ESP8266_NonOS_AT_Bin_V1.7.4.zip">ESP8266 Firmware Zipped</a></p>
+   `ESP8266 Firmware Zipped </_static/files/esp8266/ESP8266_NonOS_AT_Bin_V1.7.4.zip>`_
 
 Install python if you don't already have it installed. This quick quide shows you how to check if you already have Python and how to install it if you don't:
 

--- a/docs/contributing/website.rst
+++ b/docs/contributing/website.rst
@@ -148,6 +148,24 @@ source file, define a target:
 
     Link to the `DCC++EX home page <https://dcc-ex.com/index.html>`_.
 
+Downloads
+^^^^^^^^^
+
+Download buttons are created using the ``dcclink`` class, added using the
+``.. rst-class::`` directive:
+
+.. admonition:: Example
+
+    ::
+
+        .. rst-class:: dcclink
+
+           `Official Release page <https://github.com/DCC-EX/CommandStation-EX/releases>`_
+
+    .. rst-class:: dcclink
+
+       `Official Release page <https://github.com/DCC-EX/CommandStation-EX/releases>`_
+
 Images
 ------
 

--- a/docs/download/commandstation.rst
+++ b/docs/download/commandstation.rst
@@ -17,7 +17,7 @@ exInstaller
 
 .. raw:: html 
 
-   <p><a class="dcclink" onclick="getLink()"><span class="problematic">Automated Installer</span></a></p>
+   <p class="dcclink"><a onclick="getLink()"><span class="problematic">Automated Installer</span></a></p>
 
 |
 
@@ -26,9 +26,9 @@ Latest DCC++ EX Official Release
 
 .. note:: On the releases page, select the most recent version and download the .zip file. You will see the 2 files for download, choose the compression format you prefer: CommandStation-EX.zip or CommandStation-EX.tar.gz. The zip/tar file contains the Arduino Sketch file for DCC++ EX. You will need either the Arduino IDE or the PlatformIO development environment in order to upload it to your microcontroller board. Click here for :doc:`Arduino IDE installation instructions <../get-started/arduino-ide>`.
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="https://github.com/DCC-EX/CommandStation-EX/releases">Official Release page</a></p>
+  `Official Release page <https://github.com/DCC-EX/CommandStation-EX/releases>`_
 
 |
 
@@ -39,9 +39,9 @@ Latest DCC++ EX Unreleased Development Version
 
 .. attention:: `Discord <https://discord.gg/y2sB4Fp>`_ is the best place to keep up-to-date on new code releases, and you may be directed to download the latest version here from time to time, as new features are added and updated often.
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="https://github.com/DCC-EX/CommandStation-EX/archive/refs/heads/master.zip">Development Version</a></p>
+   `Development Version <https://github.com/DCC-EX/CommandStation-EX/archive/refs/heads/master.zip>`_
 
 |
 
@@ -50,9 +50,9 @@ CommandStation-EX Repository (project source files)
 
 .. note:: The link below will take you the the CommandStation-EX GitHub repository, where you can clone the project to your computer. Click on the green button to get a clone link or to download the zip file. We have made sure that you can still use the Arduino IDE if you like, but we recommend developers use the PlatformIO development environment. See the :doc:`Contributing Page <../contributing/index>` for more information.
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="https://github.com/DCC-EX/CommandStation-EX">CommandStation-EX GitHub</a></p>
+   `CommandStation-EX GitHub <https://github.com/DCC-EX/CommandStation-EX>`_
 
 |
 
@@ -63,9 +63,10 @@ The installer will allow you to install BaseStation-Classic. We recommend using 
 
 .. warning:: This version is not actively maintained, and will only be updated with bug fixes.
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="https://github.com/DCC-EX/BaseStation-Classic/archive/master.zip">BaseStation-Classic .zip file</a></p>
-   <p><a class="dcclink" href="https://github.com/DCC-EX/BaseStation-Classic">BaseStation-Classic GitHub</a></p>
+   `BaseStation-Classic .zip file <https://github.com/DCC-EX/BaseStation-Classic/archive/master.zip>`_
 
-|
+.. rst-class:: dcclink
+
+   `BaseStation-Classic GitHub <https://github.com/DCC-EX/BaseStation-Classic>`_

--- a/docs/download/dcc-inspector-ex.rst
+++ b/docs/download/dcc-inspector-ex.rst
@@ -9,12 +9,12 @@ DCC Inspector-EX is a packet sniffing tool that can connect directly to the sign
    :scale: 26%
    :align: left   
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <a class="dcclink" href="https://github.com/DCC-EX/DCCInspector-EX/archive/refs/heads/main.zip">DCCInspector-EX source code Zip file</a>
+   `DCCInspector-EX source code Zip file <https://github.com/DCC-EX/DCCInspector-EX/archive/refs/heads/main.zip>`_
 
 |
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <a class="dcclink" href="https://github.com/DCC-EX/DCCInspector-EX">DCCInspector-EX Github Repository</a>
+   `DCCInspector-EX Github Repository <https://github.com/DCC-EX/DCCInspector-EX">`_

--- a/docs/download/esp8266.rst
+++ b/docs/download/esp8266.rst
@@ -4,14 +4,12 @@ ESP8266 Files
 
 Espressif Flash Download tool (note: You can also use the Python tool esptool.py which is installed using the pip command)
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="../_static/files/esp8266/flash_download_tool_v3.8.5.zip">Flash Download tool</a></p>
+   `Flash Download tool </_static/files/esp8266/flash_download_tool_v3.8.5.zip>`_
 
 The 1.7.4 "NonOS AT" version of firmware we use to flash the ESP8266.
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <p><a class="dcclink" href="../_static/files/esp8266/ESP8266_NonOS_AT_Bin_V1.7.4.zip">ESP8266 Firmware</a></p>
-
-
+   `ESP8266 Firmware </_static/files/esp8266/ESP8266_NonOS_AT_Bin_V1.7.4.zip>`_

--- a/docs/reference/downloads/documents.rst
+++ b/docs/reference/downloads/documents.rst
@@ -12,9 +12,9 @@ With DCC++EX's new linear address function, there is no need to have to convert 
    :scale: 30%
    :align: left
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <a class="dcclink" href="../../_static/documents/DCCpp-stationary-decoder-addresses.xlsx">Stationary Decoder Address Table</a>
+   `Stationary Decoder Address Table </_static/documents/DCCpp-stationary-decoder-addresses.xlsx>`_
 
 .. rst-class:: clearer
 
@@ -26,9 +26,9 @@ DCC Shortcuts Card
    :scale: 26%
    :align: left
 
-.. raw:: html
+.. rst-class:: dcclink
 
-   <a class="dcclink" href="../../_static/documents/DCC_Shortcuts_Card.pdf">DCC Shortcuts Card</a>
+   `DCC Shortcuts Card </_static/documents/DCC_Shortcuts_Card.pdf>`_
 
 .. rst-class:: clearer
 
@@ -43,9 +43,9 @@ This file provides our custom scripts for JMRI, including custom buttons. You ca
    :scale: 25%
    :align: left
    
-.. raw:: html
+.. rst-class:: dcclink
 
-   <a class="dcclink" href="../../_static/documents/DCCEX_Commands_3.1.py.zip">DCC++ EX Commands JMRI Script</a>
+   `DCC++ EX Commands JMRI Script </_static/documents/DCCEX_Commands_3.1.py.zip>`_
 
 .. rst-class:: clearer
 
@@ -59,6 +59,6 @@ This file provides instruction on how to install our custom scripts in JMRI and 
    :scale: 75%
    :align: left
    
-.. raw:: html
+.. rst-class:: dcclink
 
-   <a class="dcclink" href="../../_static/documents/DCCEX_31_JMRI_Script+Button_Instructions.pdf">DCC++EX + JMRI Custom Buttons Install</a>
+   `DCC++EX + JMRI Custom Buttons Install </_static/documents/DCCEX_31_JMRI_Script+Button_Instructions.pdf>`_

--- a/docs/reference/downloads/schematics.rst
+++ b/docs/reference/downloads/schematics.rst
@@ -10,6 +10,6 @@ Mega+WiFi Board
    :scale: 12%
    :align: left 
 
-.. raw:: html
+.. rst-class:: dcclink
 
-    <a class="dcclink" href="../../_static/images/schematics/mega_wifi1.png">Mega+WiFi</a>
+   `Mega+WiFi </_static/images/schematics/mega_wifi1.png>`_

--- a/docs/throttles/ex-webthrottle.rst
+++ b/docs/throttles/ex-webthrottle.rst
@@ -42,9 +42,9 @@ Try it now (Run from the cloud)
 
 Just click this link and you will load a web page from our server that will run the web throttle on your machine. You can connect it to DCC++ EX or just run it in emulator mode where you don't have to have any hardware. Please read the requirements above for what you need in order to run exWebThrottle in your browser. If you want to remember the link to run the throttle, it is https://dcc-ex.github.io/WebThrottle-EX.
 
-.. raw:: html 
+.. rst-class:: dcclink
 
-  <p><a class="dcclink" href="https://DCC-EX.github.io/WebThrottle-EX">Try It Now</a></p>
+   `Try It Now <https://DCC-EX.github.io/WebThrottle-EX>`_
 
 WebThrottle-EX is also a Progressive Web App (PWA). That means you can install it on your computer and run it right from your start menu! If you go into the WT-EX settings panel (click the 3 line "hamburger menu" at the top left), you will find a "Settings" menu. Click on "Apps" and then select "Install as an App". You can now work offline and always find WebThrottle-EX with your other Apps!
 
@@ -53,9 +53,9 @@ Download
 
 This will install all the files to run locally on your machine. You won't need an internet connection to run the software. Just download the latest zip file from the link below and extract it to any folder you have run permission on. Then click on the index.html file to launch the throttle in your browser. Create a shortcut to it on your desktop so you can launch it more easily.
 
-.. raw:: html 
+.. rst-class:: dcclink
 
-  <p><a class="dcclink" href="https://github.com/DCC-EX/WebThrottle-EX/releases"> Download</a></p>
+   `Download <https://github.com/DCC-EX/WebThrottle-EX/releases>`_
 
 .. note:: We recommend using the version hosted on our servers as this will auto-update whenever we release a new update!
 


### PR DESCRIPTION
Use the same decoration with dcclink class but replace the raw HTML (except for the one using JavaScript) and document in Standards.

Draft because it goes after the changes in #136. This PR is only the last commit.
