### PR TITLE
URLs, Suppliers Typos

### DIFF
--- a/docs/advanced-setup/supported-motorboards/IRF3205-motor-board-setup.rst
+++ b/docs/advanced-setup/supported-motorboards/IRF3205-motor-board-setup.rst
@@ -395,7 +395,7 @@ TODO: See the PDF file IRF3205_mega_ACS724 in trains folder to include here
    Note that I was able to successfully read several decoders with 0-10A and +/-10A external current sensors, but not the recent model SD70Ace Genesis w/Tsunami2 OEM sound decoder.
    
    Locoduino site shows a method for separating the channels and adding a MAX471.
-   https://forum-locoduino-org.translate.goog/index.php?PHPSESSID=7cbbfc3255ae799160a2b9a6aa42e375&topic=843.msg10416&_x_tr_sl=fr&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=sc,elem#msg10416
+   https://forum-locoduino-org.translate.goog/index.php?topic=843.msg10416&_x_tr_sl=fr&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=sc,elem#msg10416
    
    I wonder if the 1.5 ohm 3 watt resistor could be added to this setup instead of the MAX471.
    

--- a/docs/reference/accessories/suppliers.rst
+++ b/docs/reference/accessories/suppliers.rst
@@ -39,7 +39,7 @@ David Yale
    :scale: 100%
    :align: left
 
-`David's Makerbot Thingverse page <https://www.thingiverse.com/thing:4619514?fbclid=IwAR3-iPhSOXOwbS5HytoKfxdfWuaaSgolslN52x9rp18dW1OhLEbnCUFGRs8>`_
+`David's Makerbot Thingverse page <https://www.thingiverse.com/thing:4619514>`_
 
 .. rst-class:: clearer
 
@@ -50,7 +50,7 @@ David provides the files to make a 3D printed case or can sell an alread made ca
    :scale: 40%
    :align: left
 
-`David's Makerbot Thingverse page <https://www.thingiverse.com/thing:4619514?fbclid=IwAR3-iPhSOXOwbS5HytoKfxdfWuaaSgolslN52x9rp18dW1OhLEbnCUFGRs8>`_
+`David's Makerbot Thingverse page <https://www.thingiverse.com/thing:4619514>`_
 
 .. rst-class:: clearer
 

--- a/docs/reference/accessories/suppliers.rst
+++ b/docs/reference/accessories/suppliers.rst
@@ -39,7 +39,7 @@ David Yale
    :scale: 100%
    :align: left
 
-`David's Makerbot Thingiverse page <https://www.thingiverse.com/thing:4619514>`_
+`David's Makerbot Thingiverse page <https://www.thingiverse.com/dcyale/designs>`_
 
 .. rst-class:: clearer
 
@@ -50,7 +50,7 @@ David provides the files to make a 3D printed case or can sell an already made c
    :scale: 40%
    :align: left
 
-`David's Makerbot Thingiverse page <https://www.thingiverse.com/thing:4619514>`_
+`David's DCC-EX case designs <https://www.thingiverse.com/thing:4619514>`_
 
 .. rst-class:: clearer
 

--- a/docs/reference/accessories/suppliers.rst
+++ b/docs/reference/accessories/suppliers.rst
@@ -24,7 +24,7 @@ Chesterfield sells a complete system in a 3D printed case already assembled and 
     :scale: 80%
     :align: left
 
-`Chesterfiled assembled DCC-EX Command Station <https://chesterfield-models.co.uk/product/dccex/>`_
+`Chesterfield assembled DCC-EX Command Station <https://chesterfield-models.co.uk/product/dccex/>`_
 
 .. rst-class:: clearer
 
@@ -39,18 +39,18 @@ David Yale
    :scale: 100%
    :align: left
 
-`David's Makerbot Thingverse page <https://www.thingiverse.com/thing:4619514>`_
+`David's Makerbot Thingiverse page <https://www.thingiverse.com/thing:4619514>`_
 
 .. rst-class:: clearer
 
-David provides the files to make a 3D printed case or can sell an alread made case to fit the Mega DCC-EX Command Station with a motor shield, WiFi shield, and LCD display. He has several designs.
+David provides the files to make a 3D printed case or can sell an already made case to fit the Mega DCC-EX Command Station with a motor shield, WiFi shield, and LCD display. He has several designs.
 
 .. image:: ../../_static/images/suppliers/david_yale_case.png
    :alt: David Yale DCC-EX case
    :scale: 40%
    :align: left
 
-`David's Makerbot Thingverse page <https://www.thingiverse.com/thing:4619514>`_
+`David's Makerbot Thingiverse page <https://www.thingiverse.com/thing:4619514>`_
 
 .. rst-class:: clearer
 
@@ -73,7 +73,7 @@ Chesterfield sells a case to fit the Mega DCC-EX Command Station as well as a ti
     :scale: 80%
     :align: left
 
-`Chesterfiled DCC-EX Command Station Case <https://chesterfield-models.co.uk/product/dccex/>`_
+`Chesterfield DCC-EX Command Station Case <https://chesterfield-models.co.uk/product/dccex/>`_
 
 .. rst-class:: clearer
 

--- a/docs/reference/hardware/power-supplies.rst
+++ b/docs/reference/hardware/power-supplies.rst
@@ -182,7 +182,7 @@ These come in different sizes. Show here is a 2A and a 6A Version. You can look 
 
 These are Input Voltage: DC 4-38V, error ±0.1V. Output Voltage: DC 1.25V to 36V at 5A.
 
-https://www.amazon.com/dp/B079N9BFZC?tag=amz-mkt-chr-us-20&ascsubtag=1ba00-01000-a0049-win10-other-nomod-us000-pcomp-feature-scomp-wm-5&ref=aa_scomp
+https://www.amazon.com/dp/B079N9BFZC
 
 
 Cheap Buck Converter with Display $5

--- a/docs/throttles/engine-driver.rst
+++ b/docs/throttles/engine-driver.rst
@@ -82,7 +82,7 @@ Using a Bluetooth Controller
    :scale: 50%
    :align: center
 
-`Wireless Bluetooth Gamepad/Joystick Controller <https://www.ebay.com.au/itm/Wireless-Controller-Rechargeable-Selfie-Remote-Shutter-Gamepad-Joystick-/174852677119?mkcid=16&mkevt=1&_trksid=p2349624.m46890.l49286&mkrid=711-127632-2357-0>`_
+`Wireless Bluetooth Gamepad/Joystick Controller <https://www.ebay.com.au/itm/Wireless-Controller-Rechargeable-Selfie-Remote-Shutter-Gamepad-Joystick-/174852677119>`_
 
 This is the one Steve Todd uses himself on a lanyard. It leaves both hands free for paperwork and uncoupling and is light enough to simply let go of when you need both hands. Here are his optimized settings. You can use these as a start and customize them for your own use:
 


### PR DESCRIPTION
Remove session specific fragments from a few more URLs. Some typos on the suppliers page and suggest not duplicating the same link to David's DCC-EX designs but use his Thingiverse user page as well.
