### PR TITLE
Try old sphinx-rtd-theme ver: 1.0.0 back to 0.5.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           pip3 install sphinx-sitemap
           pip3 install sphinxcontrib-spelling
       - name: Checkout repo
-        uses: actions/checkout@1.0.0
+        uses: actions/checkout@0.5.2
       - name: Build docs
         run: |
           make github

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - name: Requirements
         run: |
-          pip3 install sphinx-rtd-theme
+          pip3 install sphinx-rtd-theme==0.5.2
           pip3 install sphinx-sitemap
           pip3 install sphinxcontrib-spelling
       - name: Checkout repo
-        uses: actions/checkout@0.5.2
+        uses: actions/checkout@1.0.0
       - name: Build docs
         run: |
           make github


### PR DESCRIPTION
0.5.2 was the last known good version of sphinx-rtd-theme to work with our menu system.
Using 1.0.0 kills menu icons, and menu is not visible on mobile.
Maybe changing this back in docs.yml might fix the issue!