### PR TITLE
Point to the contributing folder instead of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-# How to Contribute to our website
-
-Thank you for your offer to help. You might want to check in with an admin from
-the DCC++ EX team before working on documentation changes to identify current needs.
-
-See docs/contributing/website.rst for the website standards and tips on how to
-get started.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DCC-EX Website Repository
 
-This Repo holds all of the resources that together form the DCC-EX documentation website. For more details on how to edit and push your changes, please read The CONTRIBUTING.MD file.
+This Repo holds all of the resources that together form the DCC-EX documentation website. For more details on how to edit and push your changes, please see the docs/contributing folder.
 
-https://github.com/DCC-EX/dcc-ex.github.io/blob/sphinx/CONTRIBUTING.md
+https://dcc-ex.com/contributing/index.html


### PR DESCRIPTION
Most of the content from CONTRIBUTING.md was already moved to
docs/contributing/website.rst and updated.

---

Link from README.md to GitHub pages. Easier to read and navigate.