### PR TITLE
Pete gsx update servo turnout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _build
 .idea
 *.xml
 *.iml
+.vscode
 
 # Compiled source #
 ###################

--- a/docs/automation/EX-RAIL-summary.rst
+++ b/docs/automation/EX-RAIL-summary.rst
@@ -241,9 +241,9 @@ Automations, Routes and Sequences
       -  Fade an LED on a servo driver to given value and taking a given time
     * -  LCN( msg )
       -  Send message to LCN Accessory Network
-    * -  SERVO( id, position, profile )
+    * -  SERVO( vpin, position, profile )
       -  Move an animation servo. Do NOT use for Turnouts. (profile is one of Instant, Fast, Medium, Slow or Bounce)
-    * -  SERVO2( id, position, duration )
+    * -  SERVO2( vpin, position, duration )
       -  Move an animation servo taking duration in ms. Do NOT use for Turnouts
     * -  XFON( cab, func )
       -  Send DCC function ON to specific cab (eg coach lights) **Not for Loco use - use FON instead!**

--- a/docs/reference/hardware/servo-module.rst
+++ b/docs/reference/hardware/servo-module.rst
@@ -52,18 +52,71 @@ servo mounting bracket, were 3d-printed on a Creality Ender-3 printer.
 Using Servos with EX-RAIL
 ==========================
 
-Defining Turnouts?
+EX-RAIL supports two methods of controlling servos:
+
+- Turnouts via the SERVO_TURNOUT directive
+- Animations via the SERVO or SERVO2 directives
 
 Controlling Servos for Turnouts
 ---------------------------------
 
-SERVO_TURNOUT Command
+The SERVO_TURNOUT directive defines a servo based turnout in EX-RAIL, which will appear in WiThrottle apps, Engine Driver, and JMRI in addition to being defined as a turnout within the CommandStation.
+
+As per the EX-RAIL reference, turnouts are defined with the following syntax:
+
+.. code-block:: cpp
+
+   SERVO_TURNOUT(id, pin, active_angle, inactive_angle, profile [, "description"])
+
+The valid paramaters are:
+- id = Unique ID within the CommandStation (note these are shared across turnouts, sensors, and outputs).
+- pin = The ID of the pin the servo is connected to, which would typically be the VPin ID of the PCA9685 controller board.
+- active_angle = The angle to which the servo will move when the turnout is thrown (refer below for further detailed information).
+- inactive_angle = The angle to which the servo will move when the turnout is closed (refer below for further detailed information).
+- profile = There are five profiles to choose from that determine the speed at which a turnout will move: Instant, Fast, Medium, Slow, and Bounce (note we don't recommend Bounce for a turnout definition).
+- description = A human-friendly description of the turnout that will appear in WiThrottle apps and Engine Driver. Note that this must be enclosed in quotes "".
+
+An example definition for a servo connected to the second control pins of the first PCA9685 connected to the CommandStation, using the slow profile for prototypical operation:
+
+.. code-block:: cpp
+
+   SERVO_TURNOUT(200, 101, 450, 110, Slow, "Example slow turnout definition")
 
 Controlling Servos for Animations
 ----------------------------------
 
-SERVO Command
+The SERVO and SERVO2 directives allow for servos to be used in various automations within EX-RAIL.
 
+Note that unlike a SERVO_TURNOUT these are not definitions that appear within WiThrottle apps, Engine Driver, or JMRI, but are instead actions designed to be used within EX-RAIL automations.
+
+As per the EX-RAIL reference, these are defined with the following syntax:
+
+.. code-block:: cpp
+
+   SERVO(vpin, position, profile)
+   SERVO2(vpin, position, duration)
+
+The valid paramaters are:
+- vpin = The ID of the pin the servo is connected to, which would typically be the VPin ID of the PCA9685 controller board.
+- position = The angle to which the servo will move when the turnout is thrown (refer below for further detailed information).
+- profile = There are five profiles to choose from that determine the speed at which a turnout will move: Instant, Fast, Medium, Slow, and Bounce.
+- duration = The time (in ms) for the servo to be actively rotating.
+
+As an example, consider a lineside worker that needs to be moved away from the track when a train approaches, which is controlled by an infrared sensor.
+
+The SERVO is attached to VPin 101 (second control pin on first PCA9685), with a sensor attached to VPin 164 (first pin on the first MCP23017):
+
+.. code-block:: cpp
+
+   AT(164)
+   SERVO(101, 400, Fast)
+   DONE
+
+   AFTER(164)
+   SERVO(101, 100, Slow)
+   DONE
+
+This tells EX-RAIL that when the sensor at VPin 164 is activated, the lineside worker moves quickly back from the track for safety, and then after the sensor has been deactivated, he can leisurely move back to his working position (no one wants to rush back to work right?).
 
 Technical Discussion for Engineers
 ====================================

--- a/docs/reference/hardware/servo-module.rst
+++ b/docs/reference/hardware/servo-module.rst
@@ -68,7 +68,8 @@ As per the EX-RAIL reference, turnouts are defined with the following syntax:
 
    SERVO_TURNOUT(id, pin, active_angle, inactive_angle, profile [, "description"])
 
-The valid paramaters are:
+The valid parameters are:
+
 - id = Unique ID within the CommandStation (note these are shared across turnouts, sensors, and outputs).
 - pin = The ID of the pin the servo is connected to, which would typically be the VPin ID of the PCA9685 controller board.
 - active_angle = The angle to which the servo will move when the turnout is thrown (refer below for further detailed information).
@@ -96,7 +97,8 @@ As per the EX-RAIL reference, these are defined with the following syntax:
    SERVO(vpin, position, profile)
    SERVO2(vpin, position, duration)
 
-The valid paramaters are:
+The valid parameters are:
+
 - vpin = The ID of the pin the servo is connected to, which would typically be the VPin ID of the PCA9685 controller board.
 - position = The angle to which the servo will move when the turnout is thrown (refer below for further detailed information).
 - profile = There are five profiles to choose from that determine the speed at which a turnout will move: Instant, Fast, Medium, Slow, and Bounce.


### PR DESCRIPTION
Have updated the servo module page to include the EX-RAIL servo definitions with examples, clarifying the need for the profile to be the text description rather than the integer, with the available options.

Have also corrected the SERVO/SERVO2 definitions in the command summary so they specify the VPin rather than an ID.

Also added .vscode to the .gitignore to ignore local .vscode directory changes.