### PR TITLE
Add PCA/TCA9555 IO Device Details

### DIFF
--- a/docs/reference/software/hal-config.rst
+++ b/docs/reference/software/hal-config.rst
@@ -179,11 +179,37 @@ There are also drivers included with DCC++ EX for the following modules:
 
 * PCF8574 - 8-channel GPIO extender module, like the MCP23017 but fewer inputs/outputs (I2C).
 * MCP23008 - Another 8-channel GPIO extender module.
+* PCA/TCA9555 - Another 16-channel GPIO extender module (see notes below).
 * DFPlayer - MP3 Media player with microSD card holder.  You can play different sounds from the player by activating or de-activating
   output VPINs from within DCC++ EX.
 * ADS1115 - Four-channel analogue input module (I2C).  Also designed to work with the ADS1113 and ADS1114 single-channel modules.
 * VL53L0X - Laser Time-Of-Flight (TOF) range sensor (I2C).  Its VPIN activates when a reflecting object is within a defined distance of the sensor.
 * HC-SR04 - Ultrasound 'sonar' range sensor.  Its VPIN activates when a reflecting object is within a defined distance of the sensor.
+
+Notes on the PCA9555/TCA9555 I2C GPIO Extenders
+-----------------------------------------------
+
+The PCA9555 is made by Texas Instruments and NXP, the TCA9555 only by Texas Instruments.
+Using these GPIO extenders is almost the same as the the MCP23017. However there are a few differences. 
+
+The PCA9555 & TCA9555 have always an internal pull-up resistor for ports configured as an input, and the INT pin is always enabled and wil trigger on a rising & falling edge of an input port.
+Both PCA9555 & TCA9555 can work with 3.3v & 5V
+
+When used for inputs (sensors or switches), the sensor/switch is usually connected between the nominated pin and the GND (ground) signal. When the sensor/switch activates, it usually connects the pin to GND, and the device detects a small current flow. When the sensor/switch deactivates, the current stops flowing. This is just the same as the Arduino digital GPIO pins.
+
+Two MCP23017 modules have been pre-defined in the CS with I2C address 0x20 and 0x21. It is save to add a PCA9555 or TCA9555 from I2C address 0x22 and up in the myHall.cpp file. See the myHal.cpp_example.txt for an example.
+
+An input pin may be configured using the DCC++ EX Sensor commands, as follows:
+
+.. code-block:: 
+  <S 801 211 1> or <S 801 211 0>
+
+Note: the 1 or 0 at the and of the command is to enable/disable the pull-up resistor, but it is not functional for the PCA/TCA as a pull-up resistor is always enable for an input port.
+
+An output port may be configured using the DCC++ EX Output commands, as follows:
+
+.. code-block:: 
+  <Z 901 196 0>
 
 Adding a New Device
 ===================

--- a/docs/reference/software/hal-config.rst
+++ b/docs/reference/software/hal-config.rst
@@ -189,15 +189,21 @@ There are also drivers included with DCC++ EX for the following modules:
 Notes on the PCA9555/TCA9555 I2C GPIO Extenders
 -----------------------------------------------
 
-The PCA9555 is made by Texas Instruments and NXP, the TCA9555 only by Texas Instruments.
-Using these GPIO extenders is almost the same as the the MCP23017. However there are a few differences. 
+The PCA9555 is made by Texas Instruments and NXP, the TCA9555 by Texas Instruments alone, and using these GPIO extenders is similar to the the MCP23017 with a few key differences.
 
-The PCA9555 & TCA9555 have always an internal pull-up resistor for ports configured as an input, and the INT pin is always enabled and wil trigger on a rising & falling edge of an input port.
-Both PCA9555 & TCA9555 can work with 3.3v & 5V
+The PCA/TCA9555 has an always-on internal pull-up resistor for ports configured as an input, and the INT pin is always enabled, meaning it will always trigger on the rising and falling edge of an input port. The PCA/TCA9555 will work with either 3.3v or 5V.
 
 When used for inputs (sensors or switches), the sensor/switch is usually connected between the nominated pin and the GND (ground) signal. When the sensor/switch activates, it usually connects the pin to GND, and the device detects a small current flow. When the sensor/switch deactivates, the current stops flowing. This is just the same as the Arduino digital GPIO pins.
 
-Two MCP23017 modules have been pre-defined in the CS with I2C address 0x20 and 0x21. It is save to add a PCA9555 or TCA9555 from I2C address 0x22 and up in the myHall.cpp file. See the myHal.cpp_example.txt for an example.
+The PCA/TCA9555 shares the same address space (0x20 to 0x27) on the I2C bus, so you need to take this into account given by default, two MCP23017s are defined in the CommandStation at addresses 0x20 and 0x21. It is recommended you set the address of the first PCA/TCA9555 to 0x22.
+
+If you need to locate a PCA/TCA9555 at 0x20 or 0x21, you will need to comment out the relevant line(s) in IODevice.cpp in the CommandStation code:
+
+.. code-block:: cpp
+  MCP23017::create(164, 16, 0x20);
+  MCP23017::create(180, 16, 0x21);
+
+See the myHal.cpp_example.txt for an example.
 
 An input pin may be configured using the DCC++ EX Sensor commands, as follows:
 

--- a/docs/reference/software/hal-config.rst
+++ b/docs/reference/software/hal-config.rst
@@ -195,22 +195,28 @@ The PCA/TCA9555 has an always-on internal pull-up resistor for ports configured 
 
 When used for inputs (sensors or switches), the sensor/switch is usually connected between the nominated pin and the GND (ground) signal. When the sensor/switch activates, it usually connects the pin to GND, and the device detects a small current flow. When the sensor/switch deactivates, the current stops flowing. This is just the same as the Arduino digital GPIO pins.
 
-The PCA/TCA9555 shares the same address space (0x20 to 0x27) on the I2C bus, so you need to take this into account given by default, two MCP23017s are defined in the CommandStation at addresses 0x20 and 0x21. It is recommended you set the address of the first PCA/TCA9555 to 0x22.
+The PCA/TCA9555 shares the same address space (0x20 to 0x27) on the I2C bus, so you need to take this into account given by default, two MCP23017s are defined in the CommandStation code at addresses 0x20 and 0x21. It is recommended you set the address of the first PCA/TCA9555 to 0x22.
 
-If you need to locate a PCA/TCA9555 at 0x20 or 0x21, you will need to comment out the relevant line(s) in IODevice.cpp in the CommandStation code:
+If you need to locate a PCA/TCA9555 at 0x20 or 0x21, you will need to comment out the relevant line(s) in IODevice.cpp in the CommandStation code.
+
+Search for and locate:
 
 .. code-block:: cpp
   MCP23017::create(164, 16, 0x20);
   MCP23017::create(180, 16, 0x21);
 
-See the myHal.cpp_example.txt for an example.
+Add "//" to comment them out:
 
-An input pin may be configured using the DCC++ EX Sensor commands, as follows:
+.. code-block:: cpp
+  //MCP23017::create(164, 16, 0x20);
+  //MCP23017::create(180, 16, 0x21);
+
+To configure an input pin using the DCC++ EX Sensor commands, use the <S> command:
 
 .. code-block:: 
   <S 801 211 1> or <S 801 211 0>
 
-Note: the 1 or 0 at the and of the command is to enable/disable the pull-up resistor, but it is not functional for the PCA/TCA as a pull-up resistor is always enable for an input port.
+As per the notes above, the 0 or 1 for the pull-up is redundant as this is always on, but the <S> command requires the parameter to be set.
 
 An output port may be configured using the DCC++ EX Output commands, as follows:
 

--- a/docs/reference/software/hal-config.rst
+++ b/docs/reference/software/hal-config.rst
@@ -197,23 +197,17 @@ When used for inputs (sensors or switches), the sensor/switch is usually connect
 
 The PCA/TCA9555 shares the same address space (0x20 to 0x27) on the I2C bus, so you need to take this into account given by default, two MCP23017s are defined in the CommandStation code at addresses 0x20 and 0x21. It is recommended you set the address of the first PCA/TCA9555 to 0x22.
 
-If you need to locate a PCA/TCA9555 at 0x20 or 0x21, you will need to comment out the relevant line(s) in IODevice.cpp in the CommandStation code.
-
-Search for and locate:
+If you need to locate a PCA/TCA9555 at 0x20 or 0x21, you will need to comment out the relevant line(s) in IODevice.cpp in the CommandStation code:
 
 .. code-block:: cpp
+
   MCP23017::create(164, 16, 0x20);
   MCP23017::create(180, 16, 0x21);
-
-Add "//" to comment them out:
-
-.. code-block:: cpp
-  //MCP23017::create(164, 16, 0x20);
-  //MCP23017::create(180, 16, 0x21);
 
 To configure an input pin using the DCC++ EX Sensor commands, use the <S> command:
 
 .. code-block:: 
+
   <S 801 211 1> or <S 801 211 0>
 
 As per the notes above, the 0 or 1 for the pull-up is redundant as this is always on, but the <S> command requires the parameter to be set.
@@ -221,6 +215,7 @@ As per the notes above, the 0 or 1 for the pull-up is redundant as this is alway
 An output port may be configured using the DCC++ EX Output commands, as follows:
 
 .. code-block:: 
+  
   <Z 901 196 0>
 
 Adding a New Device


### PR DESCRIPTION
As shared by Henkk on Discord, this is the documentation for adding PCA/TCA9555 IO extender module support.

There will be an additional PR raised some time today to add the IO_PCA9555.h device driver and update the myHal.cpp_example.txt file.