### PR TITLE
Fixed DCCInspector-EX download link

### DIFF
--- a/docs/download/dcc-inspector-ex.rst
+++ b/docs/download/dcc-inspector-ex.rst
@@ -17,4 +17,4 @@ DCC Inspector-EX is a packet sniffing tool that can connect directly to the sign
 
 .. rst-class:: dcclink
 
-   `DCCInspector-EX Github Repository <https://github.com/DCC-EX/DCCInspector-EX">`_
+   `DCCInspector-EX Github Repository <https://github.com/DCC-EX/DCCInspector-EX>`_


### PR DESCRIPTION
As reported by @pmantoine there is an extra " in the DCCInspector-EX repo link which is fixed in this PR.