### PR TITLE
179 release 402 prep

### DIFF
--- a/docs/throttles/index.rst
+++ b/docs/throttles/index.rst
@@ -16,4 +16,5 @@ For an overview of throttles and how to choose one, please read the :doc:`Gettin
     digitrainspro
     srcpclient
     streamdeck
+    tech-reference
     

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -21,7 +21,9 @@ Turnout commands
 
 **<JT>** - Returns a list of turnout IDs. The throttle should be uninterested in the turnout technology used but needs to know the IDs it can throw/close and monitor the current state.
 
-Example response: ``<jT 1 17 22 19>`` - Turnout IDS 1, 17, 22, and 19 are defined.
+Example response:
+
+* ``<jT 1 17 22 19>`` - Turnout IDS 1, 17, 22, and 19 are defined.
 
 **<JT 17>** - Returns the description for turnout ID 17, and the status of T=thrown or C=closed.
 
@@ -35,6 +37,7 @@ Example responses:
 .. note:: It is still the throttles responsibility to monitor the status broadcasts. Also note that turnouts marked in EX-RAIL with the HIDDEN keyword instead of a "description" will NOT show up in these commands.
 
 .. note:: *Note from the author:* The existing broadcast is messy and needs cleaning up, however, I'm not keen on dynamically created/deleted turnouts so I have no intention of providing a command that indicates the turnout list has been updated since the throttle started.
+  - Chris Harlow
 
 Automations/Routes
 ^^^^^^^^^^^^^^^^^^^
@@ -43,7 +46,9 @@ A throttle needs to know which EX-RAIL Automations and Routes it can show the us
 
 **<JA>** - Returns a list of Automations/Routes.
 
-Example response: ``<jA 13 16 23>`` - Indicates route/automation ids 13, 16, and 23 are defined.
+Example response:
+
+* ``<jA 13 16 23>`` - Indicates route/automation ids 13, 16, and 23 are defined.
 
 **<JA 13>** - Returns information for route/automation ID 13 including the description, and if it is a route (R) or automation (A).
 
@@ -53,36 +58,47 @@ Example responses:
 * ``<jA 13 A "description">`` - Returns the description for ID 13, and that it is an automation.
 * ``<jA 13 X>`` - Indicates ID 13 is not found.
 
-Whats the difference: 
-  A Route is just a call to an EXRAIL ROUTE, traditionally to set some turnouts or signals but can be used to perform any kind of EXRAIL function... but its not expecting to know the loco.  
-  Thus a route can be triggered by sending in for example ```</START 13>```. 
+What's the difference?
++++++++++++++++++++++++
 
-  An Automation is a handoff of the last accessed loco id to an EXRAIL AUTOMATION which would typically drive the loco away.
-  Thus an Automation expects a start command with a cab id
-  e.g. ```</START 13 3>```
+A **ROUTE** is just a call to an EX-RAIL ROUTE, traditionally to set some turnouts or signals but can be used to perform any kind of EX-RAIL function, but is not expecting to know the loco ID.
 
+* A route can be triggered by sending, for example, ``</START 13>``. 
 
-  Roster Information:
-  The ```<JR>``` command requests a list of cab ids from the roster.
-  e.g. responding ```<jR 3 200 6336>```
-  or <jR> for none. 
+An **AUTOMATION** is a handoff of the last accessed loco ID to an EX-RAIL AUTOMATION which would typically drive the loco away.
 
-  Each Roster entry had a name and function map obtained by:
-  ```<JR 200>```  reply like ```<jR 200 "Thomas" "whistle/*bell/squeal/panic">
-  
-  Refer to EXRAIL ROSTER command for function map format.
+* An automation expects a start command with a cab ID, for example ``</START 13 3>``.
 
+Roster Information
+^^^^^^^^^^^^^^^^^^^
 
-Obtaining throttle status.
-```<t cabid>```  Requests a deliberate update on the cab speed/functions in the same format as the cab broadcast.
-    ```<l cabid slot speedbyte functionMap>```
-    Note that a slot of -1 indicates that the cab is not in the reminders table and this comand will not reserve a slot until such time as the cab is throttled.
+**<JR>** - Requests a list of cab IDs from the roster.
 
+Example responses:
 
-COMMANDS TO AVOID
+* ``<jR 3 200 6336>`` - Returns the roster entry IDs 3, 200, and 6336 are defined.
+* ``<jR>`` - Indicates no roster entries are defined.
 
-```<f cab func1 func2>```     Use ```<F cab function 1/0>```
-```<t  slot cab speed dir>``` Just drop the slot number 
-```<T commands>``` other than ```<T id 0/1>```
-```<s>```
-```<c>```
+**<JR 200>** - Returns the roster name function map for roster ID 200.
+
+Example response:
+
+* ``<jR 200 "Thomas" "whistle/*bell/squeal/panic">`` - Returns the defined description "Thomas" with each defined function's name. Refer to the EX-RAIL ROSTER command for function map format.
+
+Obtaining throttle status
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**<t cabid>** - Requests a deliberate update on the cab speed/functions in the same format as the cab broadcast.
+
+Example respnse:
+
+* ``<l cabid slot speedbyte functionMap>`` - Note that a slot of -1 indicates that the cab is not in the reminders table and this comand will not reserve a slot until such time as the cab is throttled.
+
+Commands to avoid
+__________________
+
+* ``<f cab func1 func2>`` - Use ``<F cab function 1/0>`` instead.
+* ``<t  slot cab speed dir>`` - Just drop the slot number .
+* ``<T commands>`` - other than ``<T id 0/1>``.
+* ``<s>``
+* ``<c>``

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -2,4 +2,87 @@
 Technical Reference for Throttle Developers
 ********************************************
 
-This page contains all relevant information to assist those who wish to develop throttles compatible with DCC++ EX.
+This page is intended to capture relevant information to assist those who develop throttles compatible with DCC++ EX.
+
+Additional throttle commands
+_____________________________
+
+Release 4.0.2 provides a number of additional throttle information commands that have been implemented to assist throttle authors to obtain information from the Command Station in order to implement turnout, route/automation, and roster features which are already found in the Withrottle implementations. 
+
+These commands are new and do not overlap with the existing commands (which are probably due to be obsoleted as they are over complex and unfit for purpose).
+
+Turnouts
+~~~~~~~~~
+
+The conventional turnout definition commands and the ```<H>``` responses do not contain information about the turnout description which may have been provided in an EX-RAIL script. A turnout description is much more user friendly than the identifier (eg. T123), and having a list helps the throttle UI build a suitable set of buttons.
+
+Turnout commands
+^^^^^^^^^^^^^^^^^^
+
+**<JT>** - Returns a list of turnout IDs. The throttle should be uninterested in the turnout technology used but needs to know the IDs it can throw/close and monitor the current state.
+
+Example response: ``<jT 1 17 22 19>`` - Turnout IDS 1, 17, 22, and 19 are defined.
+
+**<JT 17>** - Returns the description for turnout ID 17, and the status of T=thrown or C=closed.
+
+Example responses:
+
+* ``<jT 17 T "Coal yard exit">`` - Description "Coal yard exit" plus state is thrown.
+* ``<jT 17 C "Coal yard exit">`` - Description "Coal yard exit" plus state is closed.
+* ``<jT 17 C "">`` - Indicates turnout description not defined, and state is closed.
+* ``<jT 17 X>`` - Indicates turnout unknown (or possibly hidden.)
+
+.. note:: It is still the throttles responsibility to monitor the status broadcasts. Also note that turnouts marked in EX-RAIL with the HIDDEN keyword instead of a "description" will NOT show up in these commands.
+
+.. note:: *Note from the author:* The existing broadcast is messy and needs cleaning up, however, I'm not keen on dynamically created/deleted turnouts so I have no intention of providing a command that indicates the turnout list has been updated since the throttle started.
+
+Automations/Routes
+^^^^^^^^^^^^^^^^^^^
+
+A throttle needs to know which EX-RAIL Automations and Routes it can show the user.
+
+**<JA>** - Returns a list of Automations/Routes.
+
+Example response: ``<jA 13 16 23>`` - Indicates route/automation ids 13, 16, and 23 are defined.
+
+**<JA 13>** - Returns information for route/automation ID 13 including the description, and if it is a route (R) or automation (A).
+
+Example responses:
+
+* ``<jA 13 R "description">`` - Returns the description for ID 13, and that it is a route.
+* ``<jA 13 A "description">`` - Returns the description for ID 13, and that it is an automation.
+* ``<jA 13 X>`` - Indicates ID 13 is not found.
+
+Whats the difference: 
+  A Route is just a call to an EXRAIL ROUTE, traditionally to set some turnouts or signals but can be used to perform any kind of EXRAIL function... but its not expecting to know the loco.  
+  Thus a route can be triggered by sending in for example ```</START 13>```. 
+
+  An Automation is a handoff of the last accessed loco id to an EXRAIL AUTOMATION which would typically drive the loco away.
+  Thus an Automation expects a start command with a cab id
+  e.g. ```</START 13 3>```
+
+
+  Roster Information:
+  The ```<JR>``` command requests a list of cab ids from the roster.
+  e.g. responding ```<jR 3 200 6336>```
+  or <jR> for none. 
+
+  Each Roster entry had a name and function map obtained by:
+  ```<JR 200>```  reply like ```<jR 200 "Thomas" "whistle/*bell/squeal/panic">
+  
+  Refer to EXRAIL ROSTER command for function map format.
+
+
+Obtaining throttle status.
+```<t cabid>```  Requests a deliberate update on the cab speed/functions in the same format as the cab broadcast.
+    ```<l cabid slot speedbyte functionMap>```
+    Note that a slot of -1 indicates that the cab is not in the reminders table and this comand will not reserve a slot until such time as the cab is throttled.
+
+
+COMMANDS TO AVOID
+
+```<f cab func1 func2>```     Use ```<F cab function 1/0>```
+```<t  slot cab speed dir>``` Just drop the slot number 
+```<T commands>``` other than ```<T id 0/1>```
+```<s>```
+```<c>```

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -132,5 +132,5 @@ __________________
 * ``<f cab func1 func2>`` - Use ``<F cab function 1/0>`` instead.
 * ``<t  slot cab speed dir>`` - Just drop the slot number .
 * ``<T commands>`` - other than ``<T id 0/1>``.
-* ``<s>``
-* ``<c>``
+* ``<s>`` - This may need to change in the future to support new features.
+* ``<c>`` - This may need to change in the future to support new features.

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -122,7 +122,7 @@ Obtaining throttle status
 
 ``<t cabid>`` - Requests a deliberate update on the cab speed/functions in the same format as the cab broadcast.
 
-Example respnse:
+Example response:
 
 * ``<l cabid slot speedbyte functionMap>`` - Note that a slot of -1 indicates that the cab is not in the reminders table and this comand will not reserve a slot until such time as the cab is throttled.
 

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -1,0 +1,5 @@
+********************************************
+Technical Reference for Throttle Developers
+********************************************
+
+This page contains all relevant information to assist those who wish to develop throttles compatible with DCC++ EX.

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -126,6 +126,13 @@ Example response:
 
 * ``<l cabid slot speedbyte functionMap>`` - Note that a slot of -1 indicates that the cab is not in the reminders table and this comand will not reserve a slot until such time as the cab is throttled.
 
+Where:
+
+* cabid = Loco's DCC address
+* slot = Position in the reminders table (for the convenience of slot managers later)
+* speedbyte = The DCC packet speed bye including the direction bit (NOT the same as the DCC++ speed)
+* functionmap = Binary map of which functions are ON ( 1=F0, 2=F1, 3=F0&F1   etc.)
+
 Commands to avoid
 __________________
 

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -11,21 +11,53 @@ Release 4.0.2 provides a number of additional throttle information commands that
 
 These commands are new and do not overlap with the existing commands (which are probably due to be obsoleted as they are over complex and unfit for purpose).
 
+Throttle command summary:
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All throttle specific commands are summarised here, refer below for elaboration on the details with examples.
+
+.. list-table:: 
+  :widths: auto
+  :header-rows: 1
+  :class: command-table
+
+  * - Command
+    - Response
+    - Description
+  * - ``<JT>``
+    - ``<jT ID1 ID2 ID3 ...>``
+    - Returns the defined turnout IDs.
+  * - ``<JT ID>``
+    - ``<jT ID state "[description]">``
+    - Returns the ID, state, and description of the specified turnout ID.
+  * - ``<JA>``
+    - ``<jA ID1 ID2 ID3 ...>``
+    - Returns the defined automation and route IDs.
+  * - ``<JA ID>``
+    - ``<jA ID type "[description]">``
+    - Returns the ID, type (A=automation or R=route), and description of the specified automation/route ID.
+  * - ``<JR>``
+    - ``<jR ID1 ID2 ID3 ...>``
+    - Returns the defined roster entry IDs.
+  * - ``<JR ID>``
+    - ``<jR ID "description" "function1/function2/function3/...">``
+    - Returns the ID, description, and function map of the specified roster entry ID.
+  * - ``<t cabid>``
+    - ``<l cabid slot speedbyte functionMap>``
+    - Requests a deliberate update of cab speed/functions in the same format as the cab broadcast.
+
 Turnouts
 ~~~~~~~~~
 
-The conventional turnout definition commands and the ```<H>``` responses do not contain information about the turnout description which may have been provided in an EX-RAIL script. A turnout description is much more user friendly than the identifier (eg. T123), and having a list helps the throttle UI build a suitable set of buttons.
+The conventional turnout definition commands and the ``<H>`` responses do not contain information about the turnout description which may have been provided in an EX-RAIL script. A turnout description is much more user friendly than the identifier (eg. T123), and having a list helps the throttle UI build a suitable set of buttons.
 
-Turnout commands
-^^^^^^^^^^^^^^^^^^
-
-**<JT>** - Returns a list of turnout IDs. The throttle should be uninterested in the turnout technology used but needs to know the IDs it can throw/close and monitor the current state.
+``<JT>`` - Returns a list of turnout IDs. The throttle should be uninterested in the turnout technology used but needs to know the IDs it can throw/close and monitor the current state.
 
 Example response:
 
 * ``<jT 1 17 22 19>`` - Turnout IDS 1, 17, 22, and 19 are defined.
 
-**<JT 17>** - Returns the description for turnout ID 17, and the status of T=thrown or C=closed.
+``<JT 17>`` - Returns the description for turnout ID 17, and the status of T=thrown or C=closed.
 
 Example responses:
 
@@ -44,13 +76,13 @@ Automations/Routes
 
 A throttle needs to know which EX-RAIL Automations and Routes it can show the user.
 
-**<JA>** - Returns a list of Automations/Routes.
+``<JA>`` - Returns a list of Automations/Routes.
 
 Example response:
 
 * ``<jA 13 16 23>`` - Indicates route/automation ids 13, 16, and 23 are defined.
 
-**<JA 13>** - Returns information for route/automation ID 13 including the description, and if it is a route (R) or automation (A).
+``<JA 13>`` - Returns information for route/automation ID 13 including the description, and if it is a route (R) or automation (A).
 
 Example responses:
 
@@ -72,14 +104,14 @@ An **AUTOMATION** is a handoff of the last accessed loco ID to an EX-RAIL AUTOMA
 Roster Information
 ^^^^^^^^^^^^^^^^^^^
 
-**<JR>** - Requests a list of cab IDs from the roster.
+``<JR>`` - Requests a list of cab IDs from the roster.
 
 Example responses:
 
 * ``<jR 3 200 6336>`` - Returns the roster entry IDs 3, 200, and 6336 are defined.
 * ``<jR>`` - Indicates no roster entries are defined.
 
-**<JR 200>** - Returns the roster name function map for roster ID 200.
+``<JR 200>`` - Returns the roster name function map for roster ID 200.
 
 Example response:
 
@@ -88,7 +120,7 @@ Example response:
 Obtaining throttle status
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**<t cabid>** - Requests a deliberate update on the cab speed/functions in the same format as the cab broadcast.
+``<t cabid>`` - Requests a deliberate update on the cab speed/functions in the same format as the cab broadcast.
 
 Example respnse:
 


### PR DESCRIPTION
Added the "Technical Reference for Throttle Developers" page in the Throttles hierarchy of the site, with content from @Asbelos ThrottleAssists.md file for the 4.0.2 release.