### PR TITLE
Update Programming reference

### DIFF
--- a/docs/reference/software/command-reference.rst
+++ b/docs/reference/software/command-reference.rst
@@ -706,6 +706,15 @@ WRITE CV BYTE TO ENGINE DECODER ON PROGRAMMING TRACK
 
 Writes, and then verifies, a Configuration Variable BYTE to the decoder of an engine on the programming track  
 
+* Write CV BYTE Format is: ``<W CV VALUE>``
+* ``CV`` : The number of the Configuration Variable memory location in the decoder to write to (1-1024  ).  
+* ``VALUE`` : The value to be written to the Configuration Variable memory location (0-255).
+
+  * ``RETURNS:`` ``<r CV Value>``
+  * ``CV:`` The number of the Configuration Variable memory location written to.
+  * ``Value:`` Is a number from 0-255 as read from the CV, or -1 if verification read fails.
+
+**Deprecated old format below, please use the new, brief <W CV VALUE> command instead**
 
 * Write CV BYTE Format is: ``<W CV VALUE CALLBACKNUM CALLBACKSUB>``
 * ``CV`` : The number of the Configuration Variable memory location in the decoder to write to (1-1024  ).  

--- a/docs/reference/software/command-summary.rst
+++ b/docs/reference/software/command-summary.rst
@@ -54,7 +54,7 @@ Programming track
 
  ``<W  cv value >``
 
- ``<W  cv value callbacknum callbacksub>`` Legacy version.
+ ``<W  cv value callbacknum callbacksub>`` **Deprecated, please use <W cv value> instead**
 
  ``<B cv bit 0|1>`` Write bit to cv.
 
@@ -62,7 +62,7 @@ Programming track
 
  ``<R cv>`` Read CV BYTE (pending implementation)
 
- ``<R cv callbacknum callbacksub>`` Read CV BYTE (pending legacy) 
+ ``<R cv callbacknum callbacksub>`` Read CV BYTE **Deprecated, please use <V cv value> instead**
 
  ``<V cv value>`` Verify/Read of cv with guessed value
 


### PR DESCRIPTION
Added reference details for \<W CV Value\> with deprecation of old command.

Added deprecation note to \<R cv callbacknum callbacksub\> in favour of \<V cv value\>.