### PR TITLE
Update Documentation Contribution Info and Correct I2C Display page

### DIFF
--- a/docs/contributing/requirements.rst
+++ b/docs/contributing/requirements.rst
@@ -1,6 +1,6 @@
-**************
+*************
 Requirements
-**************
+*************
 
 We assume, since you got here, that you already have a computer up and running being either a Linux, macOS, or Windows machine, as well as a working internet connection and some disk space available. 
 
@@ -9,13 +9,13 @@ A 64 bit operating system is preferred, running as much as possible the latest v
 The following sections describe what else you need for participating in the different efforts.
 
 Documentation
-================
+==============
 
 If you concentrate on documentation, no additional hardware requirements exist. Keep reading on, but be reassured if you don't feel comfortable with the following don't worry, we will find a way to have you contributing by other means.
 Just go to the Contact Us section, and we will find a way of getting you on board, or help you out getting things set up.
 
 reStructuredText
-------------------
+_________________
 
 All documentation is done using reStructuredText, for which you can find information on the official website: `reStructuredText <https://docutils.sourceforge.io/rst.html>`_
 or the `Sphinx <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ document builder tool website, which we discuss later on in this chapter.
@@ -23,9 +23,8 @@ reStructuredText is a markdown type language, for typesetting documents from web
 
 reStructuredText `QuickReference Guide <https://docutils.sourceforge.io/docs/user/rst/quickref.html>`_ 
 
-
 Git & GitHub
---------------
+_____________
 
 You should have some knowledge about Git and GitHub, as we manage all of our documentation (as well as the development) there. Depending on the editing platform of your choice, you may get all the Git functionality you need. You may want to install GitHub Desktop or Sourcetree for getting a good idea on the state of the DCC++EX documentation GitHub repository (dcc-ex.github.io).
 
@@ -36,64 +35,93 @@ Download `GitHub Desktop <https://desktop.github.com/>`_
 Download `SourceTree <https://www.sourcetreeapp.com/>`_
 
 Editing
---------
+________
 
-You will also need to choose a text editor. Yes, any text editor will do, even the most simple one, but they will not provide editing help. We suggest you use the free VSC (Visual Studio Code) which provides additional components that will make your editing easier with syntax highlighting, text snippets, and live preview of the rendering of the file, as well as integration with GitHub. Using a simple text editor will require you handling the Git integration yourself.
+You will also need to choose a text editor. Yes, any text editor will do, even the most simple one, but they will not provide editing help. We suggest you use the free VSCode (Visual Studio Code) which provides additional components that will make your editing easier with syntax highlighting, text snippets, and live preview of the rendering of the file, as well as integration with GitHub. Using a simple text editor will require you handling the Git integration yourself.
 
-Download VSC `here <https://code.visualstudio.com/download>`_ 
+Download VSCode `here <https://code.visualstudio.com/download>`_
 
 Install the following extensions:
-rst
+
+* reStructuredText by LeXtudio Inc.
+* reStructuredText Syntax highlighting by Trond Snekvik.
 
 The final website will be rendered from the rst text files using Sphinx, which you also need to install with some options which you'll find in the next paragraph.
 
+VSCode rst warnings
+^^^^^^^^^^^^^^^^^^^^
+
+Note you will likely encounter various syntax warnings in VSCode using the recommended extensions, and these should simply be ignored.
+
+To ignore these, navigate to Settings in VSCode (<Ctrl + ,>), enter "restructured" in the search bar, and click on "Edit in settings.json".
+
+Add this section:
+
+.. code-block:: 
+
+  "restructuredtext.linter.doc8.extraArgs": [ 
+      "--ignore D001", 
+      "--ignore D002", 
+      "--ignore D004"
+  ]
+
+Save and close the settings, and the irrelevant warnings should no longer bother you.
+
 Sphinx
---------
+_______
 
 Sphinx is a transformation tool, taking rst formatted documents and turning them into a static html website, PDF, or LaTex documents.
 
 Sphinx needs Python v3, so if you don't have python installed, it's time to do this now.
-Install python how-to ---TODO: to be done ---
 
-Once this is done you should also add the following extension to VSC --- to be done --- in order to enable the live preview of the documentation you write.
+The simplest way to install Python on Windows is via the Microsoft Store. Install the latest version of Python 3 available.
 
+Live preveiew
+^^^^^^^^^^^^^^
+
+The reStructuredText extension installed with VSCode allows live previewing of the web pages.
+
+When installing you will be prompted to choose the preview method, with the "Esbonio language server" being the better option of the two, albeit more resource intensive as it will generate the preview every time you save.
+
+Note, however, that the Esbonio server will only generate live previews of the pages you are actively editing, and therefore it will not give you a complete updated view of the entire website.
+
+Refer to the :doc:`/contributing/website` contributing page for more info on generating reliable local previews.
 
 Images
-----------
+_______
 
 We typically like compressed PNG files, but can take JPG as well. The resolution should be 72dpi and at least 600 pixels wide (maximum 1200). We can size the images using Sphinx to reduce them as necessary to fit where we need them on the page.
 
 Graphs & Schemas
------------------
+_________________
 
 Use draw.io to keep compatibility and allow group collaboration on the same document. Not everyone has access to Microsoft Visio. Export any schema or graph from draw.io in PNG format, with settings if possible as outlined above.
 
 --- to be done graphviz to be added ---
 
 Hidden Pages (Not ready for release)
-------------------------------------
+_____________________________________
 
 Use the ``:orphan:`` tag with a comment below it saying "Remove orphan field when the document is added to a toctree". This will allow us to easily search for the word "orphan" to find incomplete pages and avoids triggering an error that there are pages without an entry in a toctree
 
 Hidden comments
-----------------
+________________
 
 You can hide notes or searchable placeholders by putting placing the text on a line with a space above and below and preceding it with two period and a space, ex: ".. This is a hidden comment"
 
 
 Summary
----------
-
+________
 
 Code documentation
---------------------
+___________________
 
 *Work in progress*
 
 Once you have gone through all this, head to the documentation section to see how it all works.
 
 Development
-=============
+============
 
 Additional hardware
 - Arduino / motorshield setup as you can find in :ref: 

--- a/docs/contributing/website.rst
+++ b/docs/contributing/website.rst
@@ -1,11 +1,11 @@
-***************
+**************
 Documentation
-***************
+**************
 
 Thank you for your offer to help. Here's some instructions for how to contribute. You might want to check in with an admin from the DCC++ EX team before working on documentation changes to identify current needs.
 
 Submission Procedure
-======================
+=====================
 
 Simple changes to existing pages can be created without installing any tools,
 by using the "Edit on GitHub" link. However, the preview provided on GitHub
@@ -13,13 +13,13 @@ does not fully reflect the final result. The steps listed here provide guidance
 on how to make and preview more complex changes.
 
 We will assume that you have an appropriate text editor and Git installed on
-your machine. For Windows we recommend the free `Visual Studio Code IDE (VSC)
+your machine. For Windows we recommend the free `Visual Studio Code IDE (VSCode)
 <https://code.visualstudio.com/>`_ and `GitHub Desktop <https://desktop.github.com/>`_
 or `Git Bash (the command line interface in Git) <https://git-scm.com/downloads>`_.
 
 1. Clone the `dcc-ex.github.io <https://github.com/DCC-EX/dcc-ex.github.io>`_
    website repository, to your local machine. After cloning make sure you're on
-   the sphinx branch. (`Cloning a repository in GitHub
+   the "sphinx" branch. (`Cloning a repository in GitHub
    <https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository>`_).
 
 2. Install a current version of Python 3 (which also installs pip). The
@@ -52,21 +52,88 @@ Standards
 .. highlight:: rst
 
 Headings
---------
+_________
 
-* Main Headings have asterisks above and below them
-* Subheadings are underlined with equals signs
-* The next level is underlined with underscores
-* And the next level is underlined with carets
-* The last one we use is underlined with tildes
+* Main Headings have asterisks above and below them:
 
-All heading underlines and overlines must be at least as long as the text of the heading
+  .. code-block:: 
+
+    *************
+    Main Heading
+    *************
+
+* Subheadings are underlined with equals signs:
+
+  .. code-block:: 
+
+    Subheading
+    ===========
+
+* The next level is underlined with underscores:
+
+  .. code-block:: 
+
+    Next level
+    ___________
+
+* And the next level is underlined with carets:
+
+  .. code-block:: 
+
+    Next level
+    ^^^^^^^^^^^
+
+* The last one we use is underlined with tildes:
+
+  .. code-block:: 
+
+    Last level
+    ~~~~~~~~~~~
+
+All heading underlines and overlines must be at least as long as the text of the heading, however it's recommended to make them one character longer.
+
+User level logos
+_________________
+
+On our :doc:`/get-started/levels` page, we refer to Conductor, Tinkerer, and Engineer level users, and where possible, we should be using these logos to help users understand what level the documentation is targeted at.
+
+There are two types of logos available, one suitable for callouts or panels which are simply a square graphic, and one suitable for page headings that contains the graphic and the text.
+
+Graphic logos for callouts/panels:
+
+.. image:: ../_static/images/conductor.png
+    :alt: Conductor Level
+    :scale: 40%
+  
+.. image:: ../_static/images/tinkerer.png
+    :alt: Tinkerer Level
+    :scale: 40%
+
+.. image:: ../_static/images/engineer.png
+    :alt: Tinkerer Level
+    :scale: 40%
+
+Graphic and text logos for page headings:
+
+.. image:: ../_static/images/conductor-level.png
+    :alt: Conductor Level
+    :scale: 40%
+  
+.. image:: ../_static/images/tinkerer-level.png
+    :alt: Tinkerer Level
+    :scale: 40%
+
+.. image:: ../_static/images/engineer-level.png
+    :alt: Tinkerer Level
+    :scale: 40%
+
+Refer to :ref:`contributing/website:images` below for details on how to include images, and set the scale as appropriate. A good example of the use of the different types of logos is the Turntable-EX :doc:`/turntable-ex/turntable-ex` page.
 
 Links
------
+______
 
 Internal
-^^^^^^^^
+^^^^^^^^^
 
 Sphinx cross-references are used for internal links. This ensures they are
 correct and by default will use the destination heading text as the link text.
@@ -75,11 +142,11 @@ To link to a page use ``:doc:``:
 
 .. admonition:: Example
 
-    ::
-
-        :doc:`/reference/hardware/motor-boards`
+  ::
 
     :doc:`/reference/hardware/motor-boards`
+
+  :doc:`/reference/hardware/motor-boards`
 
 The document name is a relative or absolute (within the documentation) file
 path, without the .rst suffix.
@@ -90,11 +157,11 @@ references:
 
 .. admonition:: Example
 
-    ::
-
-        :ref:`advanced-setup/motor-board-config:Configure Using the Installer`
+  ::
 
     :ref:`advanced-setup/motor-board-config:Configure Using the Installer`
+
+  :ref:`advanced-setup/motor-board-config:Configure Using the Installer`
 
 The reference is the full name of the document (the absolute path without
 a leading /), a colon, and the section heading. The full name must be used
@@ -104,14 +171,14 @@ Alternative text can be used for the link:
 
 .. admonition:: Example
 
-    ::
-
-        :ref:`WiFi configuration <advanced-setup/supported-microcontrollers/wifi-mega:Short Version of Network Setup>`
+  ::
 
     :ref:`WiFi configuration <advanced-setup/supported-microcontrollers/wifi-mega:Short Version of Network Setup>`
 
+  :ref:`WiFi configuration <advanced-setup/supported-microcontrollers/wifi-mega:Short Version of Network Setup>`
+
 External
-^^^^^^^^
+^^^^^^^^^
 
 For URLs that are shown, just use the URL:
 
@@ -149,7 +216,7 @@ source file, define a target:
     Link to the `DCC++EX home page <https://dcc-ex.com/index.html>`_.
 
 Downloads
-^^^^^^^^^
+^^^^^^^^^^
 
 Download buttons are created using the ``dcclink`` class, added using the
 ``.. rst-class::`` directive:
@@ -167,7 +234,7 @@ Download buttons are created using the ``dcclink`` class, added using the
        `Official Release page <https://github.com/DCC-EX/CommandStation-EX/releases>`_
 
 Images
-------
+_______
 
 Include images with the ``.. image::`` and ``.. figure::`` directives.
 Horizontal positioning using the ``:align:`` option needs a bit of care.
@@ -185,7 +252,7 @@ figure. Add a ``:name:`` option to be able to refer to the figure in the text
 using ``:numref:`<figure name>```.
 
 Tables
-------
+_______
 
 For titled tables use the ``.. table::`` directive, followed by the title.
 Sphinx will automatically number the table. Add a ``:name:`` option to be able

--- a/docs/reference/hardware/i2c-displays.rst
+++ b/docs/reference/hardware/i2c-displays.rst
@@ -89,8 +89,8 @@ To upload the new sketch on your Command Station
    #define LCD_DRIVER  0x3F,16,2`` 
 #. make sure to uncomment this line if it has 2 slashes in front of it by removing them.
 #. Find the 4 characters that start with ``0x`` and add the address for your I2C backpack after it. We default to 3F, but your display may be 27. The text would read ``0x27`` if that was the case.
-#. In the next field, enter the number of columns in your display. The default is 16. If you have a 20 row display, enter that instead.
-#. In the last field, enter the number of rows in your display. We default to a 2 line display. If you have a 4 line display, change this to 4.
+#. In the next field, enter the number of columns in your display. The default is 16. If you have a 20 column display, enter that instead.
+#. In the last field, enter the number of rows in your display. We default to a 2 row display. If you have a 4 row display, change this to 4.
 #. Save the file
 #. Make sure to connect the Arduino to your computer with the USB cable and click the upload button to compile and upload the updated Command Station sketch.
 


### PR DESCRIPTION
Corrected "rows" to "columns" on the I2C Display page, which closes https://github.com/DCC-EX/dcc-ex.github.io/issues/204

Updated the documentation contribution information to clarify extensions in VSCode, get the heading underlines compliant with the standard, and add guidance on using the level logos.