### PR TITLE
213 continue to expand on ex rail command reference

### DIFF
--- a/docs/automation/EX-RAIL-intro.rst
+++ b/docs/automation/EX-RAIL-intro.rst
@@ -9,7 +9,7 @@ Introduction to EX-RAIL Automation
 .. sidebar:: On this page
 
    .. contents:: 
-      :depth: 3
+      :depth: 1
       :local:
 
 Introduction

--- a/docs/automation/EX-RAIL-intro.rst
+++ b/docs/automation/EX-RAIL-intro.rst
@@ -6,24 +6,11 @@ Introduction to EX-RAIL Automation
    17 Feb 2022: *Now included* in **DCC++EX 4.0!**
    Available to download and use now!
 
-* :ref:`automation/EX-RAIL-intro:Introduction`
-* :ref:`automation/EX-RAIL-intro:Things You Can Do With EX-RAIL`
-* :ref:`automation/EX-RAIL-intro:What You Don't Need`
-* :ref:`automation/EX-RAIL-intro:How It Works`
-* :ref:`automation/EX-RAIL-intro:The Automation Process`
-* :ref:`automation/EX-RAIL-intro:Some Simple Examples`
-* :ref:`automation/EX-RAIL-intro:Defining Turnouts`
-* :ref:`automation/EX-RAIL-intro:Defining Signals`
-* :ref:`automation/EX-RAIL-intro:Starting the system`
-* :ref:`automation/EX-RAIL-intro:Drive-Away Feature`
-* :ref:`automation/EX-RAIL-intro:Roster Entries`
-* :ref:`automation/EX-RAIL-intro:Sounds`
-* :ref:`automation/EX-RAIL-intro:Sensors`
-* :ref:`automation/EX-RAIL-intro:Outputs`
-* :ref:`automation/EX-RAIL-intro:Sequence Numbers`
-* :ref:`automation/EX-RAIL-intro:Tips and Techniques`
-* :ref:`automation/EX-RAIL-intro:Why Can't I Put a Script on an SDCard?`
+.. sidebar:: On this page
 
+   .. contents:: 
+      :depth: 3
+      :local:
 
 Introduction
 ==============
@@ -41,6 +28,16 @@ To begin, let's define a few terms:
 
 Most people wanting to do animations or run trains through an automated route will use a SEQUENCE, but those with :doc:`throttles </throttles/index>` that support it (:doc:`/throttles/engine-driver`, :doc:`WebThrottle-EX </throttles/ex-webthrottle>`) can add routes and automations. Both of these terms are just tags that let throttles with this feature automatically assign sequences to control buttons. "Routes" go into route buttons and can set turnouts, signals, etc., so you can drive your train along that route. "Automations" can appear on a "handoff" button that will supply or handoff the Loco ID to EX-RAIL where it can take over and run the train autonomously. An automation example would be manually driving a train into a station and pressing the assigned handoff button in the throttle that runs an AUTOMATION to take it on a journey around the layout.
 
+Things You Can Do With EX-RAIL
+====================================
+
+- Create "Routes" which set multiple turnouts and signals at the press of a button in WebThrottle-EX or EngineDriver (other WiThrottle-compatible throttles are available)
+- Automatically drive multiple trains simultaneously, and manage complex interactions such as single line working and crossovers by setting up "Automations"
+- Drive trains manually, and hand a train over to an Automation
+- Animate accessories such as lights, crossings, or cranes
+- Intercept turnout changes to automatically adjust signals or other turnouts
+- Turn on the coffee pot when the train reaches the station
+
 .. sidebar:: A note from the Author
 
    My original aim was to see if I could create an automated layout with lots going on, that didn’t just run around in circles. Having looked at JMRI (briefly, I must say) and DCC++, I began to wonder whether I could actually make a simpler automation system, and run it entirely on the Arduino used for DCC++.
@@ -54,18 +51,6 @@ Most people wanting to do animations or run trains through an automated route wi
    Because the original DCC++ used a software design inappropriate for internal automation, I had to start by rewriting the entire Command Station code and this became DCC-EX, so automation has been in the plan from the start.
 
    - Chris Harlow
-
-
-
-Things You Can Do With EX-RAIL
-====================================
-
-- Create "Routes" which set multiple turnouts and signals at the press of a button in WebThrottle-EX or EngineDriver (other WiThrottle-compatible throttles are available)
-- Automatically drive multiple trains simultaneously, and manage complex interactions such as single line working and crossovers by setting up "Automations"
-- Drive trains manually, and hand a train over to an Automation
-- Animate accessories such as lights, crossings, or cranes
-- Intercept turnout changes to automatically adjust signals or other turnouts
-- Turn on the coffee pot when the train reaches the station
 
 What You Don't Need
 ====================

--- a/docs/automation/EX-RAIL-reference.rst
+++ b/docs/automation/EX-RAIL-reference.rst
@@ -299,6 +299,8 @@ For example:
 
 ``DELAYMINS( delay )``	Delay a number of minutes
 
+``DELAYRANDOM( min_delay, max_delay )``	Delay a random time between min and max milliseconds, see :ref:`automation/ex-rail-intro:example 7: running multiple inter-connected trains` for good examples.
+
 Delay examples:
 
 .. code-block:: cpp
@@ -314,21 +316,66 @@ Delay examples:
     GREEN(102)
     DONE
 
-``DELAYRANDOM( min_delay, max_delay )``	Delay a random time between min and max milliseconds, see :ref:`automation/ex-rail-intro:example 7: running multiple inter-connected trains` for good examples.
+Conditional statements
+^^^^^^^^^^^^^^^^^^^^^^^
 
-``IF( sensor_id )``	If sensor activated or latched, continue. Otherwise skip to ELSE or matching ENDIF
+There are a number of conditional statements available to influence flow control based on the states of sensors, signals, turnouts.
 
-``IFNOT( sensor_id )``	If sensor NOT activated and NOT latched, continue. Otherwise skip to ELSE or matching ENDIF
+All conditional activities must be terminated with an ENDIF statement.
 
-``IFGTE( sensor_id, value )``	Test if analog pin reading is greater than or equal to value (>=)
+If a conditional statement is part of an automation sequence, the sequence still needs to be terminated with a DONE statement.
+
+``IF( sensor_id )``	If sensor activated or latched, continue. Otherwise skip to ELSE or matching ENDIF.
+
+``IFNOT( sensor_id )``	If sensor NOT activated and NOT latched, continue. Otherwise skip to ELSE or matching ENDIF.
+
+The IFGTE() and IFLT() commands read the analog value from an analog input pin (A0 - A5 on an Arduino Mega??) or an analog input from an I/O expander module??. Valid values are 0 - 1023??.
+
+``IFGTE( sensor_id, value )``	Test if analog pin reading is greater than or equal to value (>=).
 
 ``IFLT( sensor_id, value )``	Test if analog pin reading is less than value (<)
 
-``IFRANDOM( percent )``	Runs commands in IF block a random percentage of the time
+Sensor examples:
 
-``IFCLOSED( turnout_id )``	Check if turnout is closed
+.. code-block:: cpp
 
-``IFTHROWN( turnout_id )``	Test if turnout is thrown
+  IF(25)          // If sensor on the CS pin 25 is activated, set a signal red, wait 10 seconds, then close a turnout.
+    RED(101)
+    DELAY(10)
+    CLOSE(200)
+  ENDIF
+
+  IFNOT(26)       // If sensor on the CS pin 26 is not activated, keep our pedestrian crossing light at 102 green, else set it red.
+    GREEN(102)
+  ELSE
+    RED(102)
+  ENDIF
+
+  IFGTE(A2, 512)  // If reading the analog input from a photoelectric light sensor exceeds 512, it's bright enough to turn the street lights off.
+    RESET(164)
+  ENDIF
+
+  IFLT(A3, 10)   // If current sensing from an analog occupancy detector had dropped below the threshold, turn off our mimic panel light, otherwise turn it on.
+    RESET(165)
+  ELSE
+    SET(165)
+  ENDIF
+
+``IFRANDOM( percent )``	Runs commands in IF block a random percentage of the time. This is handy for more realism by enabling automations that don't have to run on a schedule.
+
+.. code-block:: cpp
+
+  .. AT(165)     // When sensor 165 is activated, set a lineside merry-go-round in action for 1 minute 50% of the time.
+    IFRANDOM(50)
+      SET(166)
+      DELAYMINS(1)
+      RESET(166)
+    ENDIF
+    DONE
+
+``IFCLOSED( turnout_id )``	Check if a turnout is closed.
+
+``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
 
 ``IFRESERVE( block )``	If block is NOT reserved, reserves it and run commands in IF block. Otherwise, skip to matching ENDIF
 
@@ -347,7 +394,7 @@ Delay examples:
 Command Station Functions
 __________________________
 
-``POWERON`` Power on track and UNJOIN (not yet implemented)
+``POWERON`` Power on track and UNJOIN (not yet implemented) - this command will be available in a future release of CommandStation-EX
 
 ``POWEROFF``	Power off track
 

--- a/docs/automation/EX-RAIL-reference.rst
+++ b/docs/automation/EX-RAIL-reference.rst
@@ -5,7 +5,7 @@ EX-RAIL Command Reference
 .. sidebar:: On this page
 
   .. contents:: 
-    :depth: 3
+    :depth: 1
     :local:
 
 This is a detailed reference. For a summary version, please see :doc:`EX-RAIL Command Summary <EX-RAIL-summary>`.
@@ -38,10 +38,12 @@ Notes
 
   Therefore, you can have an AUTOMATION, a turnout, a Vpin, and a virtual block all defined with the same ID without issue as these will not relate to each other. This is probably a great reason to consider aliases to avoid confusion.
 
-Diagnostics and control
-========================
+Interactive diagnostics and control
+====================================
 
-There are some diagnostic and control commands added to the <tag> language normally used to control the Command Station over USB, WiFi or Ethernet.
+There are some diagnostic and control commands added to the <tag> language normally used to control the Command Station over USB, WiFi, or Ethernet.
+
+These can be used in the same manner as other CommandStation directives to interact with EX-RAIL sequences and objects once they have been defined in myAutomation.h and are uploaded to the CommandStation.
 
 EXRAIL
 _______
@@ -128,15 +130,17 @@ ______________
 
 ``</ UNLATCH sensor_id>``	Unlock sensor, returning to current external state, valid IDs are in the range 0 - 255.
 
-Refer to the LATCH/UNLATCH commands below for further details.
+Refer to the LATCH/UNLATCH commands in the :ref:`automation/ex-rail-reference:sensors` section below for further details.
 
 Routes, automations, and sequences
 ===================================
 
-EX-RAIL provides many commands to allow you to create routes that locomotives to follow that may involve turnouts, signals, etc. that can be automatically set to react when the loco trips a sensor.
+EX-RAIL provides many commands to allow you to create automated sequences and routes that locomotives can follow that may involve turnouts, signals, etc. that can be automatically set to react when the loco trips a sensor.
 
 Script Definition Terms
 ________________________
+
+There are three options to define these automation sequences:
 
 ``AUTOMATION( id, "description" )``	Define an automation sequence that is advertised to WiThrottles to send a train along. See :ref:`automation/ex-rail-intro:example 4: automating a train (simple loop)` for a simple example.
 
@@ -144,7 +148,7 @@ ________________________
 
 ``SEQUENCE( id )``	A general purpose automation sequence that is not advertised to WiThrottles. This may be triggered automatically on startup, or be called by other sequences or activites. See :ref:`automation/ex-rail-intro:example 3: automating various non-track items`, :ref:`automation/ex-rail-intro:example 6: single line shuttle`, and :ref:`automation/ex-rail-intro:example 7: running multiple inter-connected trains` for further examples.
 
-``ENDTASK`` or ``DONE``	Completes a Sequence/Route/Animation/Event handler, and any other automation definition as shown in the previous examples.
+``ENDTASK`` or ``DONE``	Completes a Sequence/Route/Animation/Event handler, and any other automation definition as shown in the various examples on this page and elsewhere in the EX-RAIL documentation.
 
 Conditional statements
 =======================
@@ -211,6 +215,12 @@ For both the SIGNAL/SIGNALH commands, signal colour is set using the pin defined
 
 ``SERVO_SIGNAL( vpin, red_pos, amber_pos, green_pos )`` Define a servo based signal, such as semaphore signals. Each position is an angle to turn the servo to, similar to the SERVO/SERVO2 commands, and SERVO_TURNOUT.
 
+``IFRED( signal_id )`` Test if signal is red.
+
+``IFAMBER( signal_id )`` Test if signal is amber.
+
+``IFGREEN( signal_id )`` Test if signal is green.
+
 Signal examples:
 
 .. code-block:: cpp
@@ -222,12 +232,6 @@ Signal examples:
   GREEN(25)                         // Sets our active low signal to green.
   GREEN(164)                         // Sets our active high signal to green.
   GREEN(101)                        // Sets our servo based signal to green.
-
-``IFRED( signal_id )`` Test if signal is red.
-
-``IFAMBER( signal_id )`` Test if signal is amber.
-
-``IFGREEN( signal_id )`` Test if signal is green.
 
 Turnouts
 =========
@@ -244,6 +248,14 @@ All the below turnout definitions will define turnouts that are advertised to Wi
 
 ``VIRTUAL_TURNOUT( id [, "description"] )`` Define a virtual turnout, which is backed by another automation sequence. For a good example of this refer to :ref:`automation/ex-rail-intro:realistic turnout sequeunces`.
 
+``IFCLOSED( turnout_id )``	Test if a turnout is closed.
+
+``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
+
+``ONCLOSE( turnout_id )``	Event handler for when a turnout is sent a close command. Note that there can be only one defined ONCLOSE event for a specific turnout.
+
+``ONTHROW( turnout_id )``	Event handler for when a turnout is sent a throw command. Note that there can be only one defined ONTHROW event for a specific turnout.
+
 Examples:
 
 .. code-block:: cpp
@@ -253,43 +265,39 @@ Examples:
   SERVO_TURNOUT(102, 102, 400, 100, Slow, HIDDEN)   // A servo turnout on a PCA9685 servo module that is hidden from throttles.
   VIRTUAL_TURNOUT(103, "Lumber Yard")               // A virtual turnout which will trigger an automation sequence when CLOSE or THROW is sent.
 
-``IFCLOSED( turnout_id )``	Check if a turnout is closed.
-
-``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
-
-``ONCLOSE( turnout_id )``	Event handler for when a turnout is sent a close command. Note that there can be only one defined ONCLOSE event for a specific turnout.
-
-``ONTHROW( turnout_id )``	Event handler for when a turnout is sent a throw command. Note that there can be only one defined ONTHROW event for a specific turnout.
-
 Sensors
 ========
+
+``AT( sensor_id )`` An event handler that defines what to do when a sensor is active/triggered.
+
+``AFTER( sensor_id )``	An event handler that defines what to do after a sensor has been triggered and then is off for 0.5 seconds.
+
+``ATTIMEOUT( sensor_id, timeout_ms )``	A time based event handler that defines what to do when a sensor is active/triggered or if the timer runs out, then continues and sets a testable "timed out" flag.
 
 ``IF( sensor_id )``	If sensor activated or latched, continue. Otherwise skip to ELSE or matching ENDIF.
 
 ``IFNOT( sensor_id )``	If sensor NOT activated and NOT latched, continue. Otherwise skip to ELSE or matching ENDIF.
 
-The IFGTE() and IFLT() commands read the analog value from an analog input pin (A0 - A5 on an Arduino Mega) or an analog input from an I/O expander module. Valid values are defined by the capability of the analog to digital converter in use.
-
-``IFGTE( sensor_id, value )``	Test if analog pin reading is greater than or equal to value (>=).
-
-``IFLT( sensor_id, value )``	Test if analog pin reading is less than value (<).
-
 ``IFTIMEOUT``	Tests if "timed out" flag has been set by an ATTIMEOUT() sensor reading attempt.
 
-``AT( sensor_id )``	Wait until sensor is active/triggered. This can make use of negative logic to cater for active high sensors:
+Note that with the sensor commands `IF()`, `IFNOT()`, `IFTIMEOUT()`, `AT()`, `ATTIMEOUT()`, and `AFTER()`, you can use negative values to enable the use of active HIGH sensors.
+
+For example:
 
 .. code-block:: cpp
 
   AT(40)        // Wait for pin 40 to go low.
   AT(-40)       // Wait for pin 40 to go high.
 
-``ATTIMEOUT( sensor_id, timeout_ms )``	Wait until sensor is active/triggered, or if the timer runs out, then continue and set a testable "timed out" flag
+``ATGTE( analogpin, value )``  Waits for an analog pin to reach the specified value.
 
-``ATGTE( analogpin, value )``  Waits for analog pin to reach value
+``ATLT ( analogpin, value )`` Waits for an analog pin to go below the specified value.
 
-``ATLT ( analogpin, value )`` Waits for analog pin to go below value
+``IFGTE( sensor_id, value )``	Test if analog pin reading is greater than or equal to value (>=).
 
-``AFTER( sensor_id )``	Waits for sensor to trigger and then go off for 0.5 seconds
+``IFLT( sensor_id, value )``	Test if analog pin reading is less than value (<).
+
+All the `IFGTE()`, `IFLT()`, `ATGTE()`and `ATLT()` commands read the analog value from an analog input pin (A0 - A5 on an Arduino Mega) or an analog input from an I/O expander module. Valid values are defined by the capability of the analog to digital converter in use.
 
 Sensor examples:
 
@@ -317,11 +325,11 @@ Sensor examples:
     SET(165)
   ENDIF
 
+LATCH/UNLATCH can be used to maintain the state of a sensor, or can also be used to trigger a virtual sensor to act as a state flag for EX-RAIL. As this effects the state of a sensor, it can be tested via IF/IFNOT and will also work with AT/AFTER.
+
 ``LATCH( sensor_id )``	Latches a sensor on (Sensors 0-255 only).
 
 ``UNLATCH( sensor_id )``	Remove LATCH on sensor.
-
-LATCH/UNLATCH can be used to maintain the state of a sensor, or can also be used to trigger a virtual sensor to act as a state flag for EX-RAIL. As this effects the state of a sensor, it can be tested via IF/IFNOT and will also work with AT/AFTER.
 
 In this example, LATCH/UNLATCH is used to toggle between two different activities each time the ROUTE is selected in a WiThrottle:
 
@@ -344,6 +352,61 @@ In this example, LATCH/UNLATCH is used to toggle between two different activitie
       ACTIVATEL(BayExitStarter)
       LATCH(ROUTE_TOGGLE)         // LATCH ROUTE_TOGGLE to indicate route set
     ENDIF
+  DONE
+
+Output and servo commands
+==========================
+
+``SET( pin )``	Set an output pin HIGH
+
+``RESET( pin )``	Reset output pin (set to LOW)
+
+``CLOSE( turnout_id )``	Close a defined turnout
+
+``THROW( id )``	Throw a defined turnout
+
+``GREEN( signal_id )``	Set a defined signal to GREEN (see SIGNAL)
+
+``AMBER( signal_id )``	Set a defined signal to Amber. (See SIGNAL)
+
+``RED( signal_id )``	Set defined signal to Red (See SIGNAL)
+
+``FADE( pin, value, ms )``	Fade an LED on a servo driver to given value taking given time
+
+``LCN( msg )``	Send message to LCN Accessory Network
+
+``SERVO( id, position, profile )``	Move an animation servo. Do NOT use for Turnouts. (profile is one of Instant, Fast, Medium, Slow or Bounce)
+
+``SERVO2( id, position, duration )``	Move an animation servo taking duration in ms. Do NOT use for Turnouts
+
+``WAITFOR( pin )``	The WAITFOR() command instructs EX-RAIL to wait for a servo motion to complete prior to continuing.
+
+A couple of examples:
+
+.. code-block:: cpp
+
+  // First example defines a servo turnout for the coal yard and a signal for the main line.
+  TURNOUT(100, 26, 0, "Coal Yard")
+  SIGNAL(25, 26, 27)
+
+  // When our turnout is closed, the main line is open, so the signal is green.
+  ONCLOSE(100)
+    GREEN(25)
+  DONE
+
+  // When our turnout is closed, the main line is interrupted, so the signal is red.
+  ONTHROW(100)
+    RED(25)
+  DONE
+
+  // This example triggers an automation sequence when a DCC accessory decoder is activated, including waiting for SERVO motions to complete.
+  ONACTIVATEL(100)            // Activating DCC accessory decoder with linear address 100 commences the sequence.
+    SERVO(101, 400, Slow)     // Move the first servo and wait.
+    WAITFOR(101)
+    SERVO(102, 300, Medium)   // Move the second servo and wait.
+    WAITFOR(102)
+    SET(165)                  // Activate a Vpin to turn an LED on.
+    SET(166)                  // Activate a second Vpin to turn a second LED on.
   DONE
 
 Flow Control Functions
@@ -542,58 +605,3 @@ DCC Accessory decoder commands
 ``XFOFF( cab, func )``	Send DCC function OFF to specific cab (eg coach lights) Not for Loco use - use FON instead!
 
 All the above "ON" commands are event handlers that trigger a sequence of commands to run when the event occurs. These can vary from the most basic tasks such as setting signals when turnouts are closed or thrown, to triggering complete automation sequences via a DCC accessory decoder.
-
-Output and servo commands
-==========================
-
-``SET( pin )``	Set an output pin HIGH
-
-``RESET( pin )``	Reset output pin (set to LOW)
-
-``CLOSE( turnout_id )``	Close a defined turnout
-
-``THROW( id )``	Throw a defined turnout
-
-``GREEN( signal_id )``	Set a defined signal to GREEN (see SIGNAL)
-
-``AMBER( signal_id )``	Set a defined signal to Amber. (See SIGNAL)
-
-``RED( signal_id )``	Set defined signal to Red (See SIGNAL)
-
-``FADE( pin, value, ms )``	Fade an LED on a servo driver to given value taking given time
-
-``LCN( msg )``	Send message to LCN Accessory Network
-
-``SERVO( id, position, profile )``	Move an animation servo. Do NOT use for Turnouts. (profile is one of Instant, Fast, Medium, Slow or Bounce)
-
-``SERVO2( id, position, duration )``	Move an animation servo taking duration in ms. Do NOT use for Turnouts
-
-``WAITFOR( pin )``	The WAITFOR() command instructs EX-RAIL to wait for a servo motion to complete prior to continuing.
-
-A couple of examples:
-
-.. code-block:: cpp
-
-  // First example defines a servo turnout for the coal yard and a signal for the main line.
-  TURNOUT(100, 26, 0, "Coal Yard")
-  SIGNAL(25, 26, 27)
-
-  // When our turnout is closed, the main line is open, so the signal is green.
-  ONCLOSE(100)
-    GREEN(25)
-  DONE
-
-  // When our turnout is closed, the main line is interrupted, so the signal is red.
-  ONTHROW(100)
-    RED(25)
-  DONE
-
-  // This example triggers an automation sequence when a DCC accessory decoder is activated, including waiting for SERVO motions to complete.
-  ONACTIVATEL(100)            // Activating DCC accessory decoder with linear address 100 commences the sequence.
-    SERVO(101, 400, Slow)     // Move the first servo and wait.
-    WAITFOR(101)
-    SERVO(102, 300, Medium)   // Move the second servo and wait.
-    WAITFOR(102)
-    SET(165)                  // Activate a Vpin to turn an LED on.
-    SET(166)                  // Activate a second Vpin to turn a second LED on.
-  DONE

--- a/docs/automation/EX-RAIL-reference.rst
+++ b/docs/automation/EX-RAIL-reference.rst
@@ -2,6 +2,12 @@
 EX-RAIL Command Reference
 **************************
 
+.. sidebar:: On this page
+
+  .. contents:: 
+    :depth: 3
+    :local:
+
 This is a detailed reference. For a summary version, please see :doc:`EX-RAIL Command Summary <EX-RAIL-summary>`.
 
 `CommandStation-EX <https://github.com/DCC-EX/CommandStation-EX>`_ Provides full automation and accessory control through the Extended Railroad Automation Instruction Language (EX-RAIL). First, make sure you have the latest release of the `CommandStation-EX Firmware <https://github.com/DCC-EX/CommandStation-EX>`_.
@@ -33,7 +39,7 @@ Notes
 
   Therefore, you can have an AUTOMATION, a turnout, a Vpin, and a virtual block all defined with the same ID without issue as these will not relate to each other. This is probably a great reason to consider aliases to avoid confusion.
 
-DIAGNOSTICS AND CONTROL
+Diagnostics and control
 ========================
 
 There are some diagnostic and control commands added to the <tag> language normally used to control the Command Station over USB, WiFi or Ethernet.
@@ -125,8 +131,8 @@ ______________
 
 Refer to the LATCH/UNLATCH commands below for further details.
 
-ROUTES, AUTOMATIONS, & SEQUENCES
-=================================
+Routes, automations, and sequences
+===================================
 
 EX-RAIL provides many commands to allow you to create routes that locomotives to follow that may involve turnouts, signals, etc. that can be automatically set to react when the loco trips a sensor.
 
@@ -319,21 +325,26 @@ Delay examples:
 Conditional statements
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-There are a number of conditional statements available to influence flow control based on the states of sensors, signals, turnouts.
+There is quite a variety of conditional statements available to influence flow control based on the states of sensors, signals, turnouts.
 
 All conditional activities must be terminated with an ENDIF statement.
 
 If a conditional statement is part of an automation sequence, the sequence still needs to be terminated with a DONE statement.
 
+Sensor conditions
+~~~~~~~~~~~~~~~~~~
+
 ``IF( sensor_id )``	If sensor activated or latched, continue. Otherwise skip to ELSE or matching ENDIF.
 
 ``IFNOT( sensor_id )``	If sensor NOT activated and NOT latched, continue. Otherwise skip to ELSE or matching ENDIF.
 
-The IFGTE() and IFLT() commands read the analog value from an analog input pin (A0 - A5 on an Arduino Mega??) or an analog input from an I/O expander module??. Valid values are 0 - 1023??.
+The IFGTE() and IFLT() commands read the analog value from an analog input pin (A0 - A5 on an Arduino Mega) or an analog input from an I/O expander module. Valid values are defined by the capability of the analog to digital converter in use.
 
 ``IFGTE( sensor_id, value )``	Test if analog pin reading is greater than or equal to value (>=).
 
-``IFLT( sensor_id, value )``	Test if analog pin reading is less than value (<)
+``IFLT( sensor_id, value )``	Test if analog pin reading is less than value (<).
+
+``IFTIMEOUT``	Tests if "timed out" flag has been set by an ATTIMEOUT() sensor reading attempt (see :ref:`automation/ex-rail-reference:sensor input and event handlers` below).
 
 Sensor examples:
 
@@ -361,6 +372,33 @@ Sensor examples:
     SET(165)
   ENDIF
 
+Turnout and block reservation conditionals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``IFCLOSED( turnout_id )``	Check if a turnout is closed.
+
+``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
+
+``IFRESERVE( block )``	If block is NOT reserved, reserves it and run commands in IF block. Otherwise, skip to matching ENDIF
+
+Signal conditionals
+~~~~~~~~~~~~~~~~~~~~
+
+``IFRED( signal_id )`` Test if signal is red.
+
+``IFAMBER( signal_id )`` Test if signal is amber.
+
+``IFGREEN( signal_id )`` Test if signal is green.
+
+Signal examples:
+
+``ELSE``	Provides alternative logic to any IF related command returning False
+
+``ENDIF``	Required to end an IF/IFNOT/etc (Used in all IF.. functions)
+
+Other conditionals
+~~~~~~~~~~~~~~~~~~~
+
 ``IFRANDOM( percent )``	Runs commands in IF block a random percentage of the time. This is handy for more realism by enabling automations that don't have to run on a schedule.
 
 .. code-block:: cpp
@@ -372,24 +410,6 @@ Sensor examples:
       RESET(166)
     ENDIF
     DONE
-
-``IFCLOSED( turnout_id )``	Check if a turnout is closed.
-
-``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
-
-``IFRESERVE( block )``	If block is NOT reserved, reserves it and run commands in IF block. Otherwise, skip to matching ENDIF
-
-``IFTIMEOUT``	Tests if "timed out" flag has been set by an ATTIMEOUT sensor reading attempt
-
-``IFRED( signal_id )`` Test if signal is red
-
-``IFAMBER( signal_id )`` Test if signal is amber
-
-``IFGREEN( signal_id )`` Test if signal is green
-
-``ELSE``	Provides alternative logic to any IF related command returning False
-
-``ENDIF``	Required to end an IF/IFNOT/etc (Used in all IF.. functions)
 
 Command Station Functions
 __________________________

--- a/docs/automation/EX-RAIL-reference.rst
+++ b/docs/automation/EX-RAIL-reference.rst
@@ -276,7 +276,12 @@ The IFGTE() and IFLT() commands read the analog value from an analog input pin (
 
 ``IFTIMEOUT``	Tests if "timed out" flag has been set by an ATTIMEOUT() sensor reading attempt.
 
-``AT( sensor_id )``	Wait until sensor is active/triggered
+``AT( sensor_id )``	Wait until sensor is active/triggered. This can make use of negative logic to cater for active high sensors:
+
+.. code-block:: cpp
+
+  AT(40)        // Wait for pin 40 to go low.
+  AT(-40)       // Wait for pin 40 to go high.
 
 ``ATTIMEOUT( sensor_id, timeout_ms )``	Wait until sensor is active/triggered, or if the timer runs out, then continue and set a testable "timed out" flag
 

--- a/docs/automation/EX-RAIL-reference.rst
+++ b/docs/automation/EX-RAIL-reference.rst
@@ -147,11 +147,8 @@ ________________________
 
 ``ENDTASK`` or ``DONE``	Completes a Sequence/Route/Animation/Event handler, and any other automation definition as shown in the previous examples.
 
-Object Definitions
-___________________
-
 Aliases
-^^^^^^^^
+========
 
 ``ALIAS( name[, value] )``	Aliases assigns names to values. They can go anywhere in the script. If a value is not assigned, a unique ID will be assigned based on the alias "name" text.
 
@@ -192,7 +189,7 @@ Note that you could have used the command `ALIAS(COAL_YARD, 1)` in the example a
 In this simple example, aliases seem like overkill, however consider the case where you need to have the "Coal Yard" turnout closed or thrown in various different automation sequences, and you will soon see why it's easier to understand you're throwing the COAL_YARD turnout rather than turnout ID 12345.
 
 Signals
-^^^^^^^^
+========
 
 ``SIGNAL( red_pin, amber_pin, green_pin )``	Define a pin based signal, which requires three active low pins to be defined to correspond with red, amber, and green lights.
 
@@ -214,8 +211,23 @@ Signal examples:
   GREEN(164)                         // Sets our active high signal to green.
   GREEN(101)                        // Sets our servo based signal to green.
 
+``IFRED( signal_id )`` Test if signal is red.
+
+``IFAMBER( signal_id )`` Test if signal is amber.
+
+``IFGREEN( signal_id )`` Test if signal is green.
+
+Signal examples:
+
+``ELSE``	Provides alternative logic to any IF related command returning False
+
+``ENDIF``	Required to end an IF/IFNOT/etc (Used in all IF.. functions)
+
 Turnouts
-^^^^^^^^^
+=========
+
+Object definitions
+___________________
 
 All the below turnout definitions will define turnouts that are advertised to WiThrottle apps, Engine Driver, and JMRI, unless the HIDDEN keyword is used.
 
@@ -237,6 +249,23 @@ Examples:
   PIN_TURNOUT(101, 164, "Switching Yard")           // Pin turnout on an MCP23017 I/O expander module.
   SERVO_TURNOUT(102, 102, 400, 100, Slow, HIDDEN)   // A servo turnout on a PCA9685 servo module that is hidden from throttles.
   VIRTUAL_TURNOUT(103, "Lumber Yard")               // A virtual turnout which will trigger an automation sequence when CLOSE or THROW is sent.
+
+``IFCLOSED( turnout_id )``	Check if a turnout is closed.
+
+``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 Flow Control Functions
 _______________________
@@ -372,29 +401,11 @@ Sensor examples:
     SET(165)
   ENDIF
 
-Turnout and block reservation conditionals
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``IFCLOSED( turnout_id )``	Check if a turnout is closed.
-
-``IFTHROWN( turnout_id )``	Test if a turnout is thrown.
+Blocks
+=======
 
 ``IFRESERVE( block )``	If block is NOT reserved, reserves it and run commands in IF block. Otherwise, skip to matching ENDIF
 
-Signal conditionals
-~~~~~~~~~~~~~~~~~~~~
-
-``IFRED( signal_id )`` Test if signal is red.
-
-``IFAMBER( signal_id )`` Test if signal is amber.
-
-``IFGREEN( signal_id )`` Test if signal is green.
-
-Signal examples:
-
-``ELSE``	Provides alternative logic to any IF related command returning False
-
-``ENDIF``	Required to end an IF/IFNOT/etc (Used in all IF.. functions)
 
 Other conditionals
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/automation/EX-RAIL-summary.rst
+++ b/docs/automation/EX-RAIL-summary.rst
@@ -125,9 +125,9 @@ __________________________________
     * -  DELAYRANDOM( min_delay, max_delay )
       -  Delay a random time between min and max milliseconds
     * -  IF( sensor_id )
-      -  If sensor activated or latched, continue. Otherwise skip to ELSE or matching ENDIF
+      -  If sensor activated or latched, continue, otherwise skip to ELSE/ENDIF, use negative values for active HIGH sensors
     * -  IFNOT( sensor_id )
-      -  If sensor NOT activated and NOT latched, continue. Otherwise skip to ELSE or matching ENDIF
+      -  If sensor NOT activated and NOT latched, continue, otherwise skip to ELSE/ENDIF, use negative values for active HIGH sensors
     * -  IFCLOSED( turnout_id )
       -  Check if turnout is closed
     * -  IFGTE( sensor_id, value )
@@ -223,15 +223,15 @@ __________________________________
     * -  :category:`--- Sensor input & event handlers ---`
       -
     * -  AT( sensor_id )
-      -  Wait until sensor is active/triggered
+      -  Wait until sensor is active/triggered, use negative values for active HIGH sensors
     * -  ATTIMEOUT( sensor_id, timeout_ms )
-      -  Wait until sensor is active/triggered, or if the timer runs out, then continue and set a testable "timed out" flag
+      -  Wait until sensor is active/triggered, or if the timer runs out, then continue and set a testable "timed out" flag, use negative values for active HIGH sensors
     * -  ATGTE( analogpin, value)
       -  waits for analog pin to reach value
     * -  ATLT (analogpin,value)
       -  waits for analog pin to go below value
     * -  AFTER( sensor_id )
-      -  Waits for sensor to trigger and then go off for 0.5 seconds
+      -  Waits for sensor to trigger and then go off for 0.5 seconds, use negative values for active HIGH sensors
     * -  LATCH( sensor_id )
       -  Latches a sensor on (Sensors 0-255 only)
     * -  UNLATCH( sensor_id )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,14 +83,20 @@ html_logo = "./_static/images/logo.png"
 
 html_favicon = "./_static/images/favicon.ico"
 
+# Added commented out lines below for 'titles_only' and 'navigation_depth'.
+# If we wish to have the menu expand to lower levels than just page titles,
+# uncomment these lines and comment the other option out to enable this in
+# the menu.
 html_theme_options = {
     'style_nav_header_background': 'white',
     'logo_only': True,
     # Toc options
     'includehidden': True,
+    # 'titles_only': False,
     'titles_only': True,
     'collapse_navigation': False,
-    'navigation_depth': -1 
+    # 'navigation_depth': 3
+    'navigation_depth': -1
 }
 
 html_context = {

--- a/docs/throttles/tech-reference.rst
+++ b/docs/throttles/tech-reference.rst
@@ -25,22 +25,22 @@ All throttle specific commands are summarised here, refer below for elaboration 
     - Response
     - Description
   * - ``<JT>``
-    - ``<jT ID1 ID2 ID3 ...>``
+    - ``<jT id1 id2 id3 ...>``
     - Returns the defined turnout IDs.
-  * - ``<JT ID>``
-    - ``<jT ID state "[description]">``
+  * - ``<JT id>``
+    - ``<jT id state "[description]">``
     - Returns the ID, state, and description of the specified turnout ID.
   * - ``<JA>``
-    - ``<jA ID1 ID2 ID3 ...>``
+    - ``<jA id1 id2 id3 ...>``
     - Returns the defined automation and route IDs.
-  * - ``<JA ID>``
-    - ``<jA ID type "[description]">``
+  * - ``<JA id>``
+    - ``<jA id type "[description]">``
     - Returns the ID, type (A=automation or R=route), and description of the specified automation/route ID.
   * - ``<JR>``
-    - ``<jR ID1 ID2 ID3 ...>``
+    - ``<jR id1 id2 id3 ...>``
     - Returns the defined roster entry IDs.
-  * - ``<JR ID>``
-    - ``<jR ID "description" "function1/function2/function3/...">``
+  * - ``<JR id>``
+    - ``<jR id "description" "function1/function2/function3/...">``
     - Returns the ID, description, and function map of the specified roster entry ID.
   * - ``<t cabid>``
     - ``<l cabid slot speedbyte functionMap>``

--- a/docs/turntable-ex/get-started.rst
+++ b/docs/turntable-ex/get-started.rst
@@ -6,6 +6,12 @@ Getting started
   :alt: Conductor Level
   :scale: 50%
 
+.. sidebar:: On this page
+
+  .. contents:: 
+    :depth: 2
+    :local:
+
 Assembly
 =========
 
@@ -99,7 +105,7 @@ Summary table of all connections required during assembly:
 Of course for the Tinkerers and Engineers, if you're not using a Nano or a prototyping shield, adapt the details as suits your configuration.
 
 1. BEFORE you start
-^^^^^^^^^^^^^^^^^^^^
+____________________
 
 Gather all your components and visually check them all for any obvious damage, paying particular attention to pins on the Arduino to make sure they are straight.
 
@@ -112,7 +118,7 @@ Gather all your components and visually check them all for any obvious damage, p
   :scale: 50%
 
 2. Insert the Nano into the shield
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+___________________________________
 
 Insert the Nano into the prototype shield socket, taking care to ensure the USB socket is located at the same end as the DC power jack, and that all pins are straight and aligned correctly with the female headers.
 
@@ -135,7 +141,7 @@ With the shield used in these assembly photos, you will note that each of the Na
   :scale: 50%
 
 3. Connect the stepper controller and motor
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+____________________________________________
 
 Firstly, note that the ULN2003 controller will have four pins marked "IN1" through "IN4", as well as a pair of pins with "+" and "-". There is a likely a jumper installed across two pins beside these that is unmarked, leave this in place.
 
@@ -180,7 +186,7 @@ Insert the stepper motor connector into the recepticle on the ULN2003 controller
   :scale: 50%
 
 4. Connect the hall effect sensor
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+__________________________________
 
 The hall effect sensor has three pins, and likely only two of these pins are marked, the left with "-" and right with "S". The middle pin is likely to be unmarked, and will be the 5V pin. There are probably many different varieties of sensors and designs out there, but both that I have (from different suppliers) are marked identically.
 
@@ -209,7 +215,7 @@ Use three of the Dupont wires and connect these from the hall effect sensor to t
   :scale: 50%
 
 5. Connect the dual relay board
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+________________________________
 
 Note there should be six pins on the dual relay board marked "VCC", "GND", "IN1", "IN2", "COM", and "GND". The "COM" and "GND" pins should have a jumper installed to connect these together. Leave this in place.
 
@@ -240,7 +246,7 @@ Use four Dupont wires to connect the other four pins as below:
   :scale: 50%
 
 6. Connect power and test
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+__________________________
 
 At this point, it should be safe to plug in the power supply to the DC power jack on the prototyping shield.
 
@@ -261,7 +267,7 @@ To validate the hall effect sensor is connected correctly, put a magnet in close
   :scale: 50%
 
 7. Load the Turntable-EX software
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+__________________________________
 
 .. tip:: 
 
@@ -288,7 +294,7 @@ If you don't have the magnet installed at this point, or if it is too far from t
 If your testing of the hall effect sensor in step 6 above succeeded, then the issue is likely to be the distance the magnet is from the sensor, and this will require adjustment. See :ref:`turntable-ex/troubleshooting:troubleshooting turntable-ex` for further assistance if required.
 
 Automatic calibration
-""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: 
 
@@ -316,7 +322,7 @@ At this point, the full turn step count is written to the Arduino's EEPROM so th
 You can now safely power off Turntable-EX and remove the USB cable from your PC as it is no longer required for normal operation, and all further commands will be issued by the CommandStation.
 
 8. Add the Turntable-EX device driver to CommandStation-EX
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+___________________________________________________________
 
 .. note:: 
 
@@ -404,7 +410,7 @@ Follow the rest of the directions for :ref:`reference/software/hal-config:adding
 Note there is no point in checking the driver at this stage as Turntable-EX is not connected, and will show as "OFFLINE".
 
 9. Connect Turntable-EX to your CommandStation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_______________________________________________
 
 To control Turntable-EX from your CommandStation, you will need a connection to the I2C (SDA, SCL) pins.
 

--- a/docs/turntable-ex/index.rst
+++ b/docs/turntable-ex/index.rst
@@ -5,11 +5,11 @@ Turntable-EX (Beta)
 Welcome to the home of Turntable-EX, a fully integrated turntable controller for DCC++ EX.
 
 .. toctree::
-    :maxdepth: 1
+  :maxdepth: 1
 
-    turntable-ex
-    get-started
-    test-and-tune
-    traverser
-    configure
-    troubleshooting
+  turntable-ex
+  get-started
+  test-and-tune
+  traverser
+  configure
+  troubleshooting

--- a/docs/turntable-ex/test-and-tune.rst
+++ b/docs/turntable-ex/test-and-tune.rst
@@ -6,6 +6,12 @@ Testing, Tuning, and Control
   :alt: Conductor Level
   :scale: 50%
 
+.. sidebar:: On this page
+
+  .. contents:: 
+    :depth: 2
+    :local:
+
 Turntable-EX commands
 ======================
 

--- a/docs/turntable-ex/traverser.rst
+++ b/docs/turntable-ex/traverser.rst
@@ -6,6 +6,12 @@ Traversers and Limited Rotation Turntables
   :alt: Tinkerer Level
   :scale: 50%
 
+.. sidebar:: On this page
+
+  .. contents:: 
+    :depth: 2
+    :local:
+
 Overview
 =========
 

--- a/docs/turntable-ex/turntable-ex.rst
+++ b/docs/turntable-ex/turntable-ex.rst
@@ -6,22 +6,32 @@ Overview
   :alt: Conductor Level
   :scale: 50%
 
+.. sidebar:: On this page
+
+  .. contents:: 
+    :depth: 2
+    :local:
+
 What is Turntable-EX?
 ======================
-
-.. note:: 
-
-  Turntable-EX is in public Beta testing, and as such, we encourage regular feedback on the success or otherwise of both the software and documentation. Please reach out via any of our support methods and help us get Turntable-EX as easy to use and reliable as possible.
-
-  For a current overview of all outstanding feature requests or enhancements and known bugs to be fixed, visit the Turntable-EX view of the `DCC++ EX GitHub project <https://github.com/orgs/DCC-EX/projects/7/views/1>`_.
-  
-  For those who wish to help us with Beta testing, you're encouraged to follow the testing processes outlined in the `Regression Testing process <https://github.com/DCC-EX/Support-Planning/blob/master/Testing/Turntable-EX/TTEX_Regression_Testing.md>`_, and then submit your test results using the `Beta Test Results <https://github.com/DCC-EX/Turntable-EX/issues/new/choose>`_ issue template.
 
 Turntable-EX is a fully integrated turntable controller, using an additional Arduino microcontroller to drive a stepper driver to rotate a turntable and align the bridge track with the surrounding layout tracks. An Arduino Nano or Uno are suitable microcontrollers for Turntable-EX.
 
 The aim is to keep things as simple as possible, and to maintain alignment with the categories of our users as defined in our :ref:`get-started/levels:choose your level` guide for CommandStation-EX (Conductor, Tinkerer, and Engineer).
 
 The out-of-the-box example configuration should allow a Conductor level user to get up and running relatively quickly using the ubiquitous ULN2003/28BYJ-48 stepper driver and motor combination that are readily available.
+
+To make full use of Turntable-EX, you will need a basic understanding of :ref:`EX-RAIL<automation/ex-rail-intro:introduction to ex-rail automation>` automation, but we'll share the details and some examples to help with this.
+
+Essentially, if you have setup your own CommandStation, the expectation is that Turntable-EX will be a natural extension of this, and be equally as easy to setup (at least from the electronics and software perspective).
+
+.. note::
+
+  Turntable-EX is in public Beta testing, and as such, we encourage regular feedback on the success or otherwise of both the software and documentation. Please reach out via any of our support methods and help us get Turntable-EX as easy to use and reliable as possible.
+
+  For a current overview of all outstanding feature requests or enhancements and known bugs to be fixed, visit the Turntable-EX view of the `DCC++ EX GitHub project <https://github.com/orgs/DCC-EX/projects/7/views/1>`_.
+  
+  For those who wish to help us with Beta testing, you're encouraged to follow the testing processes outlined in the `Regression Testing process <https://github.com/DCC-EX/Support-Planning/blob/master/Testing/Turntable-EX/TTEX_Regression_Testing.md>`_, and then submit your test results using the `Beta Test Results <https://github.com/DCC-EX/Turntable-EX/issues/new/choose>`_ issue template.
 
 .. sidebar:: Supported stepper drivers and motors
 
@@ -36,10 +46,6 @@ The out-of-the-box example configuration should allow a Conductor level user to 
     :align: right
 
   Using other pre-defined, supported stepper drivers and motors should also be achievable at the Conductor level, but may enter into Tinkerer territory depending on the specific hardware.
-
-To make full use of Turntable-EX, you will need a basic understanding of :ref:`EX-RAIL<automation/ex-rail-intro:introduction to ex-rail automation>` automation, but we'll share the details and some examples to help with this.
-
-Essentially, if you have setup your own CommandStation, the expectation is that Turntable-EX will be a natural extension of this, and be equally as easy to setup (at least from the electronics and software perspective).
 
 The Turntable-EX integration includes:
 


### PR DESCRIPTION
Big change to the EX-RAIL reference page layout and expanded with some more content/examples.

Added sidebar contents to Turntable-EX pages and EX-RAIL pages.

Also added info on how to use/test active HIGH sensors with EX-RAIL.