### PR TITLE
230 api reference refinements

### DIFF
--- a/docs/advanced-setup/wifi-config.rst
+++ b/docs/advanced-setup/wifi-config.rst
@@ -2,14 +2,15 @@
 WiFi Configuration
 *******************
 
-.. image:: ../_static/images/conductor.png
+.. sidebar:: On this page
+
+   .. contents:: 
+    :depth: 1
+    :local:
+
+.. image:: ../_static/images/conductor-level.png
    :alt: Conductor Icon
    :scale: 50%
-   :align: left
-
-Conductor Level (Tinkerer if wiring an ESP instead of using a shield)
-
-|
 
 This page describes the software configuration options for using WiFi to connect your Command Station (CS) wirelessly to JMRI or a wireless throttle like Engine Driver. For information on how to connect your hardware, go to :doc:`WiFi Setup <../get-started/wifi-setup>`.
 
@@ -25,6 +26,15 @@ For a video, click `Setting up WiFi <https://www.youtube.com/watch?v=N6TWR7fIl0A
    .. raw:: html
 
       <iframe width="336" height="189" src="https://www.youtube.com/embed/N6TWR7fIl0A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+.. note::
+
+   .. image:: ../_static/images/tinkerer.png
+      :alt: Tinkerer Icon
+      :scale: 30%
+      :align: left
+
+   If using a separate ESP instead of a shield, this becomes tinkerer level.
 
 Wireless Connections
 =====================
@@ -68,7 +78,7 @@ Access Point Mode vs. Station Mode
 There are two ways to configure the WiFi board connected to DCC++ EX: "Access Point Mode" (aka "AP MODE"), and "Station Mode". We often abbreviate the latter to "STA". You will also see people refer to it as "Client Mode".
 
 AP Mode
---------
+________
 
 In AP mode, the tiny ESP-WiFi chip acts as a very basic WiFi server and provides a small IP network for your throttle or for your computer running JMRI and WiThrottle. It acts much like your router does to let things connect directly to it (currently up to four connections). Using the CS in AP mode allows you to have a separate network so you can keep your layout network separate from your home network. This is the simplest way to enable a connection for a WiFi throttle.
 
@@ -85,7 +95,7 @@ If you travel to shows, or take your setup to a friend's house, this allows for 
    Access Point Mode - Things connect to the WiFi Board
 
 Station Mode
--------------
+_____________
 
 Station mode allows you to connect the Command Station to your existing home network. The CS becomes a Station or Client rather than an AP. That means instead of being a host that manages the IP of the smartphone that runs your Throttle, it becomes a station that connects to your existing network just like any of the other computers or devices connected to your network. The Throttle then connects to the CS by finding its IP address on the network. You will have to find what IP address is assigned to the CS (see below). Alternately, you can define a static IP address in your router to assign to the CS.
 
@@ -141,7 +151,7 @@ You will also see your SSID and Password in the log.
 Once you see an AP IP Address and see ``++ Wifi Setup OK ++`` at the bottom of the log (it may take a few seconds for the CS to complete the configuration), you can connect to it!
 
 Connecting to the Access Point 
-----------------------------------
+_______________________________
 
 There are two steps to get you running trains with your WiFi throttle.
 
@@ -227,46 +237,48 @@ The following defines are all the possible network settings found the config.h f
 | :ref:`advanced-setup/wifi-config:#define MAC_ADDRESS {  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xEF }`
 
 #define IP_PORT 2560
---------------------
+_____________________
+
 **Default: 2560** - This is the port used to communicate with the WiFi board or Ethernet Shield. We use the default value of 2560 because that is the port JMRI uses. You can change this value if you would prefer it to be something else. You will need to enter this in software like Engine Driver in order to connect to the CS via networking.
 
 #define ENABLE_WIFI true
-------------------------
+_________________________
 **Default: true** - WiFi is supported only on a Mega. If you do not wish to use WiFi, and want to save boot time by not having the Mega check for a WiFi board each time, you may set this to "false".
 
 #define DONT_TOUCH_WIFI_CONF
-----------------------------
+_____________________________
 **Default: commented out** If uncommented, this tells the CS to NOT process any WiFi commands in the CS. If other WiFi defines are enabled, the CS will ignore them. With this command, you can leave #define ENABLE_WIFI true so that networking is active, but send no configuration commands to ESP8266. This allows you to enter your own AT commands to set up your WiFi however you want. To do this, you would enter <+> commands in the serial monitor, or add code to send these commands automatically.
 
 #define WIFI_SSID "Your network name"
---------------------------------------
+______________________________________
 **Default: "Your network name"** - To connect to your CS as an AP (Access Point), do not change this setting. If you wish to connect to your home network instead, enter the SSID (network name) for that network. If you do NOT set the WIFI_SSID, the WiFi chip will first try to connect to the previously configured network, and if that fails, fall back to Access Point mode. The SSID of the AP will be automatically set to DCCEX_xxxxxx, where xxxxxx is the last 6 digits of the MAC address for the WiFi chip.
 Your SSID may not contain ``"`` (double quote, ASCII 0x22).
 
 #define WIFI_PASSWORD "Your network passwd"
---------------------------------------------
+____________________________________________
 **Default: "Your network passwd"** - WIFI_PASSWORD is the network password for your home network, or if you want to change the password from default AP mode password to the AP password you want.  Your password may not contain ``"`` (double quote, ASCII 0x22).  
 If you don't change this setting and start up in AP mode instead, the default password is PASS_xxxxxx where xxxxxx is the last 6 digits of the MAX address for your ESP board.
 
-
 #define WIFI_HOSTNAME "dccex"
------------------------------
+______________________________
 **Default: "dccex"** You would normally not want to change this, as it is the host name that will appear in the list of available networks displayed for devices connecting to DCC-EX. It helps you know which WiFi device is your Command Station.
 
 #define WIFI_CONNECT_TIMEOUT 14000
------------------------------------
+___________________________________
 **Default: 14000 milliseconds (14 seconds)** - You only need to set this if you have an extremely slow WiFi router, and the response to the connection request takes longer than normal.
 
 #define ENABLE_ETHERNET true
------------------------------
+_____________________________
 **Default: commented out** - Uncomment this line if you wish to use an Ethernet Shield & cable (not WiFi, see above for that). You will also need to install the Arduino Ethernet Library on whichever IDE you use to compile and upload your sketch.
 
 #define IP_ADDRESS { 192, 168, 1, 200 }
-----------------------------------------
+________________________________________
 **Default: commented out** - Uncomment this line if you wish to use a static IP address, otherwise the CS will use DHCP to automatically assign an IP address from your router. If you use a static IP, you will also have to configure this IP in your router.
 
+**Note** - this is only valid when using Ethernet, and does not apply to WiFi.
+
 #define MAC_ADDRESS {  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xEF }
-------------------------------------------------------------
+____________________________________________________________
 **Default: commented out** - This is for Ethernet only! Ethernet shields do not normally come with a defined MAC address. We give you two, and you can uncomment the one you prefer. You can also choose any other validly formatted MAC address that will not conflict with any devices already on your network.
 
 
@@ -276,14 +288,14 @@ Resetting Network Settings
 Once you enter a network SSID and password, the CS will always try to connect to it, even after removing the power and restarting. If you want to connect in AP mode, or your network credentials change, or you need to connect to a different network, you simply need to tell your WiFi board to clear the settings.
 
 Clearing the ESP-WiFi SSID Settings
-------------------------------------
+____________________________________
 
 Open your serial monitor and wait until the CS has gone through the startup sequence. Then in the command textbox enter ``<+RESTORE>`` and press "SEND".
 
 You will then see an "Ok" message. The WiFi Settings are forgotten. However, if the last config.h used when you uploaded it to the CS had WiFi credentials in it, then as soon as your CS restarts, it will load and save those settings again. So...
 
 If you want to run in AP mode
-------------------------------
+______________________________
 
 Edit the config.h, change your SSID and password lines back to default. It MUST look like the following. If it is anything else it will try to login with whatever you type there as credentials!
 
@@ -295,7 +307,7 @@ Edit the config.h, change your SSID and password lines back to default. It MUST 
 Then upload the project into the CS.
 
 If you want to change your network login
-------------------------------------------
+_________________________________________
 
 Edit the config.h file, change your SSID and password to your new credentials, and then upload the project into the CS.
 
@@ -327,13 +339,13 @@ There are circumstances where you may want to make temporary changes to your net
    - Press "send" after each command.
 
 Temporarily Log Into A Different Network
------------------------------------------
+_________________________________________
 
 1. Forget your network settings by entering ``<+CWQAP>`` in the serial monitor.
 2. Login to the new network by entering either a new local SSID & password, or using the CS in AP Mode.
 
 Create a Static IP for your CS in AP Mode
-------------------------------------------
+__________________________________________
 
 You are still going to have to go into your router, find the MAC address for your WiFi board (or find it in the serial monitor log) and then assign a static IP address (sometimes called "reserved" IP address) to that MAC. That should be all you need, as the DHCP server on your network will assign that IP to your CS when the CS asks for one.
 

--- a/docs/developer-reference/api.rst
+++ b/docs/developer-reference/api.rst
@@ -1,6 +1,6 @@
-*************************
-API syntax documentation
-*************************
+********************************
+CommandStation-EX API Reference
+********************************
 
 .. image:: ../_static/images/engineer-level.png
   :alt: Engineer Level
@@ -12,6 +12,17 @@ API syntax documentation
     :depth: 1
     :local:
 
+.. list-table:: 
+  :widths: auto
+  :stub-columns: 1
+
+  * - Document status
+    - Draft
+  * - Document version
+    - 0.1
+  * - Last update
+    - 5th June 2022
+
 This page documents the API syntax and usage for CommandStation-EX.
 
 The current API has resulted from a mix of new commands and commands inherited from the original DCC++ code base, and therefore there are some noted exceptions to the syntax, however all new commands and responses must conform to the correct syntax.
@@ -20,8 +31,8 @@ If you are looking for information on the WiThrottle protocol, you will find tha
 
 For detailed information on the various commands and responses available with DCC++ EX, refer to the :doc:`/reference/software/command-reference` page.
 
-Serial port and WiFi/Ethernet monitoring
-=========================================
+1. Serial port and WiFi/Ethernet monitoring
+============================================
 
 The input collectors must monitor the serial ports on a byte by byte basis, look for a beginning "<" with ending ">", and ignore anything outside that before passing commands in for parsing.
 
@@ -29,8 +40,8 @@ The WiFI or ethernet collectors work on a per-transmission basis and the first b
 
 **Any input received that a throttle does not understand must be discarded and ignored.**
 
-General API command usage and responses
-========================================
+2. General API command usage and responses
+===========================================
 
 API commands are sent using the message format outlined below, with responses conforming to the same format.
 

--- a/docs/developer-reference/api.rst
+++ b/docs/developer-reference/api.rst
@@ -27,82 +27,131 @@ This page documents the API syntax and usage for CommandStation-EX.
 
 The current API has resulted from a mix of new commands and commands inherited from the original DCC++ code base, and therefore there are some noted exceptions to the syntax, however all new commands and responses must conform to the correct syntax.
 
+.. note:: 
+
+  Legacy commands and responses that do not comply with this documented syntax will be deprecated in future versions.
+
 If you are looking for information on the WiThrottle protocol, you will find that documented on the `JMRI website <https://www.jmri.org/help/en/package/jmri/jmrit/withrottle/Protocol.shtml>`_.
 
 For detailed information on the various commands and responses available with DCC++ EX, refer to the :doc:`/reference/software/command-reference` page.
 
-1. Serial port and WiFi/Ethernet monitoring
+1. API Client definition
+=========================
+
+This API reference applies to any API client that makes use of these commands and responses.
+
+API clients may include:
+
+- Throttles (both wired and wireless)
+- JMRI
+- Other integrations (eg. RedHat)
+
+2. Serial port and WiFi/Ethernet monitoring
 ============================================
 
-The input collectors must monitor the serial ports on a byte by byte basis, look for a beginning "<" with ending ">", and ignore anything outside that before passing commands in for parsing.
+The input collectors must monitor the serial ports on a byte by byte basis, look for a beginning ``<`` with ending ``>``, and ignore anything outside that before passing commands in for parsing.
 
 The WiFI or ethernet collectors work on a per-transmission basis and the first byte of input determines whether the transmitted block gets sent for parsing as an API or WiThrottle command or response.
 
-**Any input received that a throttle does not understand must be discarded and ignored.**
+**Any input received that an API client does not understand must be discarded and ignored.**
 
-2. General API command usage and responses
+3. General API command usage and responses
 ===========================================
 
-API commands are sent using the message format outlined below, with responses conforming to the same format.
+API commands are to be sent using the message format outlined below, with responses conforming to the same format.
 
-Due to the nature of DCC++ EX being able to be operated by multiple throttles concurrently combined with the fact there is no unique throttle identifier, there is no guarantee that a response received directly after a command is sent is related. Care must be taken to take this into account.
+Due to the nature of DCC++ EX being able to be operated by multiple API clients concurrently combined with the fact there is no unique client identifier, there is no guarantee that a response received directly after a command is sent is related. Care must be taken to take this into account.
 
-To repeat from above, any input received that a throttle does not understand should be discarded and ignored.
+To repeat from above, any input received that an API client does not understand should be discarded and ignored.
 
-Command responses
-__________________
+3.1. Command responses
+_______________________
 
-Command responses should conform to the syntax standard to ensure they are processed correctly by throttles.
+Command responses should conform to the syntax standard to ensure they are processed correctly by API clients.
 
-Broadcast responses
-____________________
+3.2. Broadcast responses
+_________________________
 
-Broadcast information is sent to all throttles along with WiThrottle responses on the understanding that throttles will discard and ignore any responses they do not understand.
+Broadcast information is sent to all API clients along with WiThrottle responses on the understanding that API clients will discard and ignore any responses they do not understand.
 
-It is mandatory that a throttle accepts and ignores a broadcast it doesn't understand.
+It is mandatory that an API client accepts and ignores a broadcast it doesn't understand.
 
-Diagnostics and other responses
-________________________________
+3.3. Diagnostics and other responses
+_____________________________________
 
 If diagnostic commands are enabled, these are sent to the USB serial port.
 
-If you connect a throttle to the USB serial port, you will get these correctly wrapped but do not expect to understand them. 
+If you connect an API client to the USB serial port, you will get these correctly wrapped but do not expect to understand them. 
 
-If, however, WiFi debug is enabled, or the <+> command is used, then the wrapping can no longer be guaranteed as the wifi traffic may contain "\*>".
+If, however, WiFi debug is enabled, or the ``<+>`` command is used, then the wrapping can no longer be guaranteed as the wifi traffic may contain ``*>``.
 
-General Message Format
-=======================
+4. General Message Format
+==========================
 
-A DCC++EX API message consists of a leading "<" symbol, a single character OPCODE, zero to n parameters separated by spaces, and a terminating ">" symbol:
+A DCC++EX API message consists of a leading ``<`` symbol, a single character OPCODE, zero to n parameters separated by spaces, and a terminating ``>`` symbol:
 
 ``<OPCODE Param1 Param2 … ParamX>``
 
-Messages cannot be nested, and a second "<" inside a message constitutes a syntax error.
+Messages cannot be nested, and a second ``<`` inside a message constitutes a syntax error.
 
-Error responses
-================
+5. Error responses
+===================
 
 A command sent that is invalid or returns an error has a response of ``<X>``.
 
-Memory limitations of prohibit more detailed error messages.
+Memory limitations prohibit more detailed error messages.
 
-Parameter parsing sequence
-===========================
+6. Parameter values
+====================
+
+Parameters containing ``a-z``, ``A-Z``, or ``_`` are hashed to create integers. Thus a command like ``<D WIFI ON>`` is internally identical to ``<D wifi on>``.
+
+The translation of parameters from text to integer is base10 unless noted in :ref:`developer-reference/api:a.1. parameter values`.
+
+There are three types of parameters in use:
+
+6.1. Keyword
+_____________
+
+These are a consecutive sequence of non-blank characters consisting of ``a-z``, ``A-Z``, or ``_``, eg. "JOIN", "WIFI", "ON".
+
+6.2. Numeric
+_____________
+
+These are a consective sequence of digits, with an optional leading ``-`` to indicate a negative value. Unless noted in :ref:`developer-reference/api:a.1. parameter values`, these numbers are base10.
+
+6.3. String
+____________
+
+These are surrounded by a leading and trailing ``"`` and may contain text including spaces eg. "This is a turnout description".
+
+Appendix A. Exceptions
+=======================
+
+A.1. Parameter values
+______________________
+
+Due to legacy code and backwards compatibility requirements, there are two OPCODES that expect hexadecimal parameter values.
+
+These are the ``<M>`` and ``<P>`` commands documented in the :ref:`reference/software/command-reference:send packet to the track` section of the Command Reference.
+
+Appendix B. Suggested parameter parsing sequence
+=================================================
 
 To obtain the parameters:
 
-Obtain the OPCODE
-__________________
+B.1. Obtain the OPCODE
+_______________________
 
-The first level of parsing is to obtain the single character, case sensitive OPCODE which is preceeded by a "<" character.
+The first level of parsing is to obtain the single character, case sensitive OPCODE which is preceeded by a ``<`` character.
 
-Obtain the parameters
-______________________
+B.2. Obtain the parameters
+___________________________
 
-The second level of parsing takes the next non-blank parameter along with each blank separated parameter and turns them into integers. There are no decimal point or float inputs. A prefix "-" may be used.
+The second level of parsing takes the next non-blank parameter along with each blank separated parameter and turns them into integers. There are no decimal point or float inputs. A prefix ``-`` may be used.
 
-Example command and response
-_____________________________
+B.3. Example command and response
+__________________________________
 
 A simple example is sending an API command to retrieve the list of defined turnouts.
 
@@ -113,17 +162,3 @@ Using our syntax standard, "J" is the OPCODE, and "T" is the parameter.
 The response for this command will look something like ``<jT 1 17>``.
 
 Using our parsing sequence, we obtain the OPCODE "j", with the subsequent parameters being "T", "1", and "17".
-
-Parameter values
-=================
-
-Parameters containing "a-z", "A-Z", or "_" are hashed to create integers. Thus a command like <D WIFI ON> is internally identical to <D wifi on>.
-
-The translation of parameters from text to integer is base10.
-
-Exceptions
-___________
-
-Due to legacy code and backwards compatibility requirements, there are two OPCODES that expect hexadecimal parameter values.
-
-These are the ``<M>`` and ``<P>`` commands documented in the :ref:`reference/software/command-reference:send packet to the track` section of the Command Reference.


### PR DESCRIPTION
Corrected non-standard heading underlines in the WiFi documentation, and added clarification on static IP definition. Also updated conductor/tinkerer information and moved from references to sidebar contents.

Renamed API reference page to be CommandStation-EX API Reference and incorporated feedback from Hans.