### PR TITLE
Fix templates - about instead of description

### DIFF
--- a/.github/ISSUE_TEMPLATE/decoder_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/decoder_feedback.yml
@@ -1,5 +1,5 @@
 name: DCC Decoder Feedback
-about: Use this template to submit feedback on DCC decoders tested with EX-CommandStation
+description: Use this template to submit feedback on DCC decoders tested with EX-CommandStation
 title: "[Decoder Feedback]: "
 labels:
   - Needs Documentation

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -3,7 +3,7 @@
 # This file needs to reside in the https://github.com/DCC-EX/.github repository in the ".github/ISSUE_TEMPLATE/" folder.
 
 name: Documentation Update
-about: Submit a request for documentation updates, or to report broken links or inaccuracies
+description: Submit a request for documentation updates, or to report broken links or inaccuracies
 title: "[Documentation Update]: "
 labels:
   - Documentation

--- a/.github/ISSUE_TEMPLATE/to_do.yml
+++ b/.github/ISSUE_TEMPLATE/to_do.yml
@@ -3,7 +3,7 @@
 # This file needs to reside in the https://github.com/DCC-EX/.github repository in the ".github/ISSUE_TEMPLATE/" folder.
 
 name: To Do
-about: Create a general To Do item
+description: Create a general To Do item
 title: "[To Do]: "
 labels:
   - To Do


### PR DESCRIPTION
Corrected error in templates: need description rather than about.