### PR TITLE
384-documentation-update-consolidated-troubleshooting-section

### DIFF
--- a/docs/ex-commandstation/get-started/index.rst
+++ b/docs/ex-commandstation/get-started/index.rst
@@ -94,4 +94,4 @@ Click :doc:`here <purchasing>` or click the "next" button to see what you need t
     installer
     controllers
     testing
-    diagnosing-issues
+    /support/ex-cs-troubleshooting

--- a/docs/ex-commandstation/get-started/installer.rst
+++ b/docs/ex-commandstation/get-started/installer.rst
@@ -161,7 +161,7 @@ Even if you didn't install a WiFi shield, we recommend that this box be checked.
 .. note::
    :class: note-float-right 
 
-   If you have any difficulties check the :doc:`diagnosing-issues` page for assistance.
+   If you have any difficulties check the :doc:`/support/ex-cs-troubleshooting` page for assistance.
 
 Compile and Upload
 ------------------

--- a/docs/ex-commandstation/get-started/testing.rst
+++ b/docs/ex-commandstation/get-started/testing.rst
@@ -149,7 +149,7 @@ You will need to install |Engine Driver| on your mobile device and then connect 
 .. note:: 
    :class: note-float-right
 
-   If you have any difficulties check the :doc:`diagnosing-issues` page for assistance.
+   If you have any difficulties check the :doc:`/support/ex-cs-troubleshooting` page for assistance.
 
 * Start the |engine driver| App
 * Go through the initial startup pages to set some basic configuration items
@@ -186,7 +186,7 @@ Using wiThrottle (Apple iOS)
 .. note:: 
    :class: note-float-right
 
-   If you have any difficulties check the :doc:`diagnosing-issues` page for assistance.
+   If you have any difficulties check the :doc:`/support/ex-cs-troubleshooting` page for assistance.
 
 * If you have set up your |EX-CS| in |Access Point Mode| (The Recommended approach)
   

--- a/docs/ex-installer/installing.rst
+++ b/docs/ex-installer/installing.rst
@@ -211,7 +211,7 @@ Once you have configured your options, press this button to compile all the sour
 
 .. note:: 
 
-   If you have any difficulties check the :doc:`/ex-commandstation/get-started/diagnosing-issues` page for assistance.
+   If you have any difficulties check the :doc:`/support/ex-cs-troubleshooting` page for assistance.
 
 ----
 

--- a/docs/ex-turntable/assembly.rst
+++ b/docs/ex-turntable/assembly.rst
@@ -304,7 +304,7 @@ Once the software is loaded successfully on to |EX-TT|, the stepper motor should
 
 If you don't have the magnet installed at this point, or if it is too far from the sensor, |EX-TT| will rotate several turns prior to flagging that homing has failed, and will then cease turning. The automatic calibration process will not commence if homing has failed.
 
-If your testing of the hall effect sensor in step 6 above succeeded, then the issue is likely to be the distance the magnet is from the sensor, and this will require adjustment. See :ref:`ex-turntable/troubleshooting:troubleshooting ex-turntable` for further assistance if required.
+If your testing of the hall effect sensor in step 6 above succeeded, then the issue is likely to be the distance the magnet is from the sensor, and this will require adjustment. See :ref:`support/ex-tt-troubleshooting:troubleshooting ex-turntable` for further assistance if required.
 
 First start and automatic calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/ex-turntable/assembly.rst
+++ b/docs/ex-turntable/assembly.rst
@@ -304,7 +304,7 @@ Once the software is loaded successfully on to |EX-TT|, the stepper motor should
 
 If you don't have the magnet installed at this point, or if it is too far from the sensor, |EX-TT| will rotate several turns prior to flagging that homing has failed, and will then cease turning. The automatic calibration process will not commence if homing has failed.
 
-If your testing of the hall effect sensor in step 6 above succeeded, then the issue is likely to be the distance the magnet is from the sensor, and this will require adjustment. See :ref:`support/ex-tt-troubleshooting:troubleshooting ex-turntable` for further assistance if required.
+If your testing of the hall effect sensor in step 6 above succeeded, then the issue is likely to be the distance the magnet is from the sensor, and this will require adjustment. See :doc:`/support/ex-tt-troubleshooting` for further assistance if required.
 
 First start and automatic calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/ex-turntable/index.rst
+++ b/docs/ex-turntable/index.rst
@@ -21,7 +21,7 @@ Welcome to the home of |EX-TT|, a fully integrated turntable controller for |EX-
   test-and-tune
   layout-wiring
   configure
-  troubleshooting
+  /support/ex-tt-troubleshooting
   traverser
 
 ----

--- a/docs/ex-turntable/test-and-tune.rst
+++ b/docs/ex-turntable/test-and-tune.rst
@@ -114,7 +114,7 @@ Referring again to :ref:`reference/developers/hal-config:adding a new device`, s
   <* MCP23017 I2C:x21 Configured on Vpins:180-195 OFFLINE *>
   <* TurntableEX I2C:x60 Configured on Vpins:600-600  *>          <<== This is the important line, |EX-TT| is connected!
 
-If there is an "OFFLINE" at the end of the |EX-TT| line, it indicates something is not quite right. Refer to :ref:`ex-turntable/troubleshooting:ex-turntable showing as offline with \<d hal show\>`.
+If there is an "OFFLINE" at the end of the |EX-TT| line, it indicates something is not quite right. Refer to :ref:`support/ex-tt-troubleshooting:ex-turntable showing as offline with \<d hal show\>`.
 
 At power on, note that the turntable should have moved itself to the home position, so all commands below assume this is the case.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,10 +66,10 @@ If you are just starting your journey with |DCC-EX| we recommend you look at our
    ex-rail/index
    ex-turntable/index
    ex-dccinspector/index
+   support/index
    big-picture/index
    throttles/index
    download/index
-   support/index
    reference/index
    projects/index
    about/index

--- a/docs/support/ex-cs-troubleshooting.rst
+++ b/docs/support/ex-cs-troubleshooting.rst
@@ -25,6 +25,37 @@ NOTE: This section is a very rough draft. More coming soon.
 
 There are a lot of optional settings and choices a user can make and sometimes things don't work as you expect them to. If you upload software to the Command Station, connect power to your motor controller and the Command Station and then connect the output to your track and don't see power or your train responding, here are the steps to follow.
 
+Cannot drive a locomotive
+=========================
+
+.. list-table:: 
+  :widths: auto
+  :header-rows: 1
+  :class: command-table
+
+  * - Symptoms
+    - Common Causes
+  * - Locomotive doesn't respond to throttle settings
+    - | Track power has not been turned on - Issue ``<1>`` in the serial console, or use power button in |Engine Driver| or |JMRi|
+      | Locomotive is on the programming track - Issue ``<1 JOIN>`` in the serial console
+      | Power has not been supplied to the motor shield - Check to ensure power supply is connected securely to the motor shield, is plugged in at the wall, and turned on
+
+Cannot connect to the EX-CommandStation over WiFi
+=================================================
+
+.. list-table:: 
+  :widths: auto
+  :header-rows: 1
+  :class: command-table
+
+  * - Symptoms
+    - Common Causes
+  * - | CommandStation does not appear in the available WiThrottle server list in |Engine Driver| or |wiThrottle| apps
+      | Manually entering the expected IP address and port does not successfully connect
+    - | CommandStation is configured for Access Point mode, but |Engine Driver| or |wiThrottle| device is connected to a different WiFi network - Connect the device directly the CommandStation's WiFi network
+      | CommandStation is configured for Station Mode and connects to the WiFi network, but |Engine Driver| or |wiThrottle| device is connected to a different WiFi network - Connect the device to the correct WiFi network
+      | WifI shield is connected incorrectly to the CommandStation - The Rx pin of the WiFi shield must connect to the Tx pin on the CommandStation, and Tx to the Rx pin
+
 Is it Plugged In, Is it Turned On?
 ===================================
 

--- a/docs/support/ex-cs-troubleshooting.rst
+++ b/docs/support/ex-cs-troubleshooting.rst
@@ -6,9 +6,9 @@
 .. include:: /include/include-l2.rst
 |EX-CS-LOGO|
 
-**************************************
-Diagnosing Issues (Troubleshooting)
-**************************************
+*********************************
+Troubleshooting EX-CommandStation
+*********************************
 
 |conductor| 
 

--- a/docs/support/ex-cs-troubleshooting.rst
+++ b/docs/support/ex-cs-troubleshooting.rst
@@ -6,27 +6,41 @@
 .. include:: /include/include-l2.rst
 |EX-CS-LOGO|
 
-*********************************
-Troubleshooting EX-CommandStation
-*********************************
+*****************************************
+EX-CommandStation FAQ and Troubleshooting
+*****************************************
 
 |conductor| 
 
 .. sidebar::
 
   .. contents:: On this page
-    :depth: 1
+    :depth: 2
     :local:
 
 
-This is the "Help, it's not working!" page.
+Frequently Answered Questions
+=============================
 
-NOTE: This section is a very rough draft. More coming soon.
+This is a list of common questions that we answer by our various support channels:
 
-There are a lot of optional settings and choices a user can make and sometimes things don't work as you expect them to. If you upload software to the Command Station, connect power to your motor controller and the Command Station and then connect the output to your track and don't see power or your train responding, here are the steps to follow.
+.. list-table:: 
+  :widths: auto
+  :header-rows: 1
+  :class: command-table
+
+  * - Question
+    - Answer
+  * - Can I run a loco on the programming track?
+    - Yes, by issuing the command ``<1 JOIN>`` via the serial console
+
+Troubleshooting tips
+====================
+
+In this section, you will find some tips on troubleshooting the various issues encountered with |EX-CS|.
 
 Cannot drive a locomotive
-=========================
+-------------------------
 
 .. list-table:: 
   :widths: auto
@@ -41,7 +55,7 @@ Cannot drive a locomotive
       | Power has not been supplied to the motor shield - Check to ensure power supply is connected securely to the motor shield, is plugged in at the wall, and turned on
 
 Cannot connect to the EX-CommandStation over WiFi
-=================================================
+-------------------------------------------------
 
 .. list-table:: 
   :widths: auto
@@ -56,8 +70,11 @@ Cannot connect to the EX-CommandStation over WiFi
       | CommandStation is configured for Station Mode and connects to the WiFi network, but |Engine Driver| or |wiThrottle| device is connected to a different WiFi network - Connect the device to the correct WiFi network
       | WifI shield is connected incorrectly to the CommandStation - The Rx pin of the WiFi shield must connect to the Tx pin on the CommandStation, and Tx to the Rx pin
 
+Diagnostics
+===========
+
 Is it Plugged In, Is it Turned On?
-===================================
+----------------------------------
 
 Yes, we need to start with the basics. If you have 12V DC or less connected to the input power of the Arduino and did not cut the power connect trace underneath the Motor Controller, then the Motor Controller and the Arduino can be powered from the one power supply connected to the barrel jack of the Motor Shield. If you cut the trace (which we highly recommend), then you will need two power supplies, a 7-9V DC power supply to the Arduino and a 12-18V DC (based on the scale of your locomotives) power supply for the Motor Controller.
 
@@ -65,15 +82,15 @@ Yes, we need to start with the basics. If you have 12V DC or less connected to t
 * If you have two power supplies, see above for the Motor Controller board and add a 7-9V DC power supply for the Arduino of at least 1 Amp. Anything less than 7 Volts will cause unreliable operation
 * Do you see a green led marked ```on``` on the Arduino board glowing to indicate the Arduino has power? If not, there is a power issue
 
-Diagnosing and Testing
-=============================
+Testing
+-------
 
 #. Remove the Motor Shield ---we are going to test just the Arduino first.
 #. Download and install the most current version of :ref:`EX-CommandStation <download/ex-commandstation:Latest EX-CommandStation Official Release>`
 #. Open the Serial Monitor Window in the Arduino IDE and establish communication with the Arduino. You will need to set the serial data rate to ``115200 baud`` and make sure you have set ``Both CR & NL`` from the dropdown so that commands are accepted. If you see gibberish (garbage characters), this is usually an indication that the baud rate is incorrect. You should see "DCC-EX" and the software version as well as other log lines that mention WiFi. If you don't see anything in the log, it could be that the software did not upload correctly, less than 7 Volts DC to the Arduino, or be an issue with the connection between your computer and the Arduino. Check your serial port and try a different USB cable.
 
 Testing the Arduino and EX-CommandStation code
-==============================================
+----------------------------------------------
 
 Validating the Arduino and |EX-CS| code is functional is a pretty straight forward exercise.
 
@@ -81,7 +98,7 @@ Validating the Arduino and |EX-CS| code is functional is a pretty straight forwa
 #. If there are obvious issues noted from these startup logs, review "config.h", make sure you have downloaded the correct version of |EX-CS|, and upload the software again. 
 
 Testing the Motor Shield
-==============================
+------------------------
 
 If first two tests pass, then the Arduino is functioning correctly and it's time to test the Motor Shield.  
 
@@ -100,7 +117,7 @@ If only one of the LEDs attached to the one of the output channels comes on when
 If you still need help, please find us on Discord or send an email to support@dcc-ex.com
 
 Testing the DCC signal
-=========================
+----------------------
 
 Now the fun part -- we are going to test the generation of the DCC signal itself.  
 

--- a/docs/support/ex-tt-troubleshooting.rst
+++ b/docs/support/ex-tt-troubleshooting.rst
@@ -2,9 +2,9 @@
 .. include:: /include/include-l1.rst
 |EX-TT-LOGO|
 
-****************************
-Troubleshooting EX-Turntable
-****************************
+************************************
+EX-Turntable FAQ and Troubleshooting
+************************************
 
 |tinkerer| |githublink-ex-turntable-button2|
 
@@ -14,10 +14,28 @@ Troubleshooting EX-Turntable
     :depth: 1
     :local:
 
-You will find resolutions to a number of common issues encountered with |EX-TT| on this page.
+Frequently Answered Questions
+=============================
+
+This is a list of common questions that we answer by our various support channels:
+
+.. list-table:: 
+  :widths: auto
+  :header-rows: 1
+  :class: command-table
+
+  * - Question
+    - Answer
+  * - 
+    - 
+
+Troubleshooting tips
+====================
+
+In this section, you will find some tips on troubleshooting the various issues encountered with |EX-TT|.
 
 Homing failure
-==============
+--------------
 
 .. list-table:: 
   :widths: auto
@@ -32,7 +50,7 @@ Homing failure
       | Hall effect sensor is connected incorrectly
 
 Calibration failure
-===================
+-------------------
 
 .. list-table:: 
   :widths: auto
@@ -48,7 +66,7 @@ Calibration failure
       | Hall effect sensor is connected incorrectly
 
 Turntable judders, stalls, or fails to rotate
-=============================================
+---------------------------------------------
 
 .. list-table:: 
   :widths: auto
@@ -59,13 +77,14 @@ Turntable judders, stalls, or fails to rotate
     - Common Causes
   * - When attempting to rotate, the turntable judders or shakes
     - | An incorrect stepper driver has been configured
+      | Stepper motor or driver is not connected correctly, ensure all wiring is securely connected
       | Something is physically interfering with the turntable or stepper operation, check for interference
   * - The turntable does not rotate at all
     - | An incorrect stepper driver has been configured
       | Something is physically interfering with the turntable or stepper operation, check for interference
 
 Track power is cut when locomotive enters turntable bridge track
-================================================================
+----------------------------------------------------------------
 
 .. list-table:: 
   :widths: auto
@@ -79,7 +98,7 @@ Track power is cut when locomotive enters turntable bridge track
       | Tracks opposite each other around the turntable are wired with inverted phases, wiring must be adjusted
 
 EX-CommandStation compile errors with device driver enabled
-===========================================================
+-----------------------------------------------------------
 
 .. list-table:: 
   :widths: auto
@@ -92,7 +111,7 @@ EX-CommandStation compile errors with device driver enabled
     - The version of EX-CommandStation is incorrect, you need the "add-turntable-controller" branch of `EX-CommandStation <https://github.com/DCC-EX/CommandStation-EX/tree/add-turntable-controller>`_
 
 EX-Turntable showing as offline with <D HAL SHOW>
-=================================================
+-------------------------------------------------
 
 .. list-table:: 
   :widths: auto

--- a/docs/support/ex-tt-troubleshooting.rst
+++ b/docs/support/ex-tt-troubleshooting.rst
@@ -13,9 +13,6 @@ Troubleshooting EX-Turntable
   .. contents:: On this page
     :depth: 1
     :local:
-  
-Troubleshooting common EX-Turntable issues
-===========================================
 
 You will find resolutions to a number of common issues encountered with |EX-TT| on this page.
 

--- a/docs/support/ex-tt-troubleshooting.rst
+++ b/docs/support/ex-tt-troubleshooting.rst
@@ -17,7 +17,7 @@ Troubleshooting EX-Turntable
 You will find resolutions to a number of common issues encountered with |EX-TT| on this page.
 
 Homing failure
---------------
+==============
 
 .. list-table:: 
   :widths: auto
@@ -32,7 +32,7 @@ Homing failure
       | Hall effect sensor is connected incorrectly
 
 Calibration failure
--------------------
+===================
 
 .. list-table:: 
   :widths: auto
@@ -48,7 +48,7 @@ Calibration failure
       | Hall effect sensor is connected incorrectly
 
 Turntable judders, stalls, or fails to rotate
----------------------------------------------
+=============================================
 
 .. list-table:: 
   :widths: auto
@@ -65,7 +65,7 @@ Turntable judders, stalls, or fails to rotate
       | Something is physically interfering with the turntable or stepper operation, check for interference
 
 Track power is cut when locomotive enters turntable bridge track
-----------------------------------------------------------------
+================================================================
 
 .. list-table:: 
   :widths: auto
@@ -79,7 +79,7 @@ Track power is cut when locomotive enters turntable bridge track
       | Tracks opposite each other around the turntable are wired with inverted phases, wiring must be adjusted
 
 EX-CommandStation compile errors with device driver enabled
------------------------------------------------------------
+===========================================================
 
 .. list-table:: 
   :widths: auto
@@ -92,7 +92,7 @@ EX-CommandStation compile errors with device driver enabled
     - The version of EX-CommandStation is incorrect, you need the "add-turntable-controller" branch of `EX-CommandStation <https://github.com/DCC-EX/CommandStation-EX/tree/add-turntable-controller>`_
 
 EX-Turntable showing as offline with <D HAL SHOW>
--------------------------------------------------
+=================================================
 
 .. list-table:: 
   :widths: auto

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -2,22 +2,38 @@
 .. include:: /include/include-l1.rst
 |EX-SUPPORT-LOGO|
    
-***********************************
-Troubleshooting, Contact, & Support
-***********************************
+****************************************
+FAQ, Troubleshooting, Contact, & Support
+****************************************
 
 |conductor| |tinkerer| |engineer|
 
 .. sidebar::
 
   .. contents:: On this page
-    :depth: 1
+    :depth: 2
     :local:
+
+Frequently Answered Questions and Troubleshooting
+=================================================
+
+We've done our best to capture a lot of common questions we've provided answers to via our various support methods, along with providing some troubleshooting tips on the various issues you may encounter with our products.
+
+The following pages provide these FAQs and troubleshooting guides, and the following sections on this page outline how to get help if these don't resolve the issue.
+
+.. toctree::
+  :maxdepth: 1
+
+  ex-cs-troubleshooting
+  ex-tt-troubleshooting
+
+Contact and Support options
+===========================
 
 There are several different ways to get in contact with the team and obtain help and support for |DCC-EX|.
 
 Preferred option: Discord
-==========================
+-------------------------
 
 The best way to reach us is on our Discord server. Usually there is a team member online to help with your issue, and if not you'll get a response within a few hours.
 
@@ -36,7 +52,7 @@ For those who wish to contribute to the project, this is by far the best option 
     <center><iframe src="https://ptb.discordapp.com/widget?id=713189617066836079&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe></center><br>
 
 Raise a support ticket
-=======================
+----------------------
 
 The next best way to get our attention is to fill out a support ticket:
 
@@ -48,7 +64,7 @@ The next best way to get our attention is to fill out a support ticket:
 You can also send an email to support@dcc-ex.com.
 
 Other options
-==============
+-------------
 
 We try to follow FaceBook and JMRI groups, but there are just too many separate groups to see and respond to all the messages.
 
@@ -70,5 +86,3 @@ You can also find us on TrainBoard:
 
   contact-us
   create-ticket
-  ex-cs-troubleshooting
-  ex-tt-troubleshooting

--- a/docs/support/index.rst
+++ b/docs/support/index.rst
@@ -2,9 +2,9 @@
 .. include:: /include/include-l1.rst
 |EX-SUPPORT-LOGO|
    
-*****************
-Contact & Support
-*****************
+***********************************
+Troubleshooting, Contact, & Support
+***********************************
 
 |conductor| |tinkerer| |engineer|
 
@@ -70,3 +70,5 @@ You can also find us on TrainBoard:
 
   contact-us
   create-ticket
+  ex-cs-troubleshooting
+  ex-tt-troubleshooting


### PR DESCRIPTION
Move troubleshooting pages under support and include FAQ, renaming EX-CS diagnostics to FAQ and Troubleshooting.