### PR TITLE
Update issue/PR to project workflow

### DIFF
--- a/.github/workflows/new-items.yml
+++ b/.github/workflows/new-items.yml
@@ -13,7 +13,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - ready_for_review
       - opened


### PR DESCRIPTION
Change workflow to use pull_request_target instead of pull_request so it runs the workflow in the context of the DCC-EX organisation's repo rather than the fork.