### PR TITLE
Change to pull_request_target

### DIFF
--- a/.github/workflows/new-items.yml
+++ b/.github/workflows/new-items.yml
@@ -13,7 +13,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - ready_for_review
       - opened


### PR DESCRIPTION
Change from pull_request to pull_request_target to ensure workflow runs in context of the base repo, not the fork to prevent issues with permissions and secrets that don't exist in forks.