### PR TITLE
Allow sphinx-rtd-theme to choose the versions of sphinx & docutils

### DIFF
--- a/.github/workflows/docs-manual-build.yml
+++ b/.github/workflows/docs-manual-build.yml
@@ -9,13 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Requirements
+        # Allow sphinx-rtd-theme to choose the versions of sphinx & docutils
         run: |
-          pip3 install docutils==0.18
-          pip3 install sphinx-rtd-theme==1.0.0
-          pip3 install sphinx-sitemap
-          pip3 install sphinxcontrib-spelling
-          pip3 install sphinx-toolbox==3.4.0
-          pip3 install sphinx==5.3.0
+          pip3 install sphinx-rtd-theme==1.2.0 \
+            sphinx-sitemap sphinxcontrib-spelling sphinx-toolbox
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,13 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Requirements
+        # Allow sphinx-rtd-theme to choose the versions of sphinx & docutils
         run: |
-          pip3 install docutils==0.18
-          pip3 install sphinx-rtd-theme==1.0.0
-          pip3 install sphinx-sitemap
-          pip3 install sphinxcontrib-spelling
-          pip3 install sphinx-toolbox==3.4.0
-          pip3 install sphinx==5.3.0
+          pip3 install sphinx-rtd-theme==1.2.0 \
+            sphinx-sitemap sphinxcontrib-spelling sphinx-toolbox
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Build docs


### PR DESCRIPTION
From version 1.1.0 sphinx-rtd-theme adds upper bounds for compatible versions of sphinx and docutils.

----

An attempt to fix the installing/uninstalling seen at the moment e.g.

```
2023-03-02T12:28:04.4286579Z Collecting docutils==0.18

2023-03-02T12:28:05.0224517Z Successfully installed docutils-0.18

2023-03-02T12:28:08.4871186Z   Attempting uninstall: docutils
2023-03-02T12:28:08.4880234Z     Found existing installation: docutils 0.18
2023-03-02T12:28:08.5471041Z     Uninstalling docutils-0.18:
2023-03-02T12:28:08.5511082Z       Successfully uninstalled docutils-0.18

2023-03-02T12:28:14.7889192Z Collecting docutils<0.19,>=0.16
2023-03-02T12:28:14.7993923Z   Downloading docutils-0.18.1-py2.py3-none-any.whl (570 kB)

2023-03-02T12:28:15.4627464Z   Attempting uninstall: docutils
2023-03-02T12:28:15.4638470Z     Found existing installation: docutils 0.17.1
2023-03-02T12:28:15.5231103Z     Uninstalling docutils-0.17.1:
2023-03-02T12:28:15.5269152Z       Successfully uninstalled docutils-0.17.1
2023-03-02T12:28:15.9949243Z   Attempting uninstall: sphinx
2023-03-02T12:28:15.9958683Z     Found existing installation: Sphinx 5.3.0
2023-03-02T12:28:16.0983810Z     Uninstalling Sphinx-5.3.0:
2023-03-02T12:28:16.1061708Z       Successfully uninstalled Sphinx-5.3.0
2023-03-02T12:28:17.0650120Z ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
2023-03-02T12:28:17.0651103Z sphinx-rtd-theme 1.0.0 requires docutils<0.18, but you have docutils 0.18.1 which is incompatible.
```

N.B. It does update sphinx-rtd-theme to 1.2.0 (this only works with >= 1.1.0) and I haven't checked the output.

Another alternative would be to pin every package. At the moment:

```
2023-03-02T12:28:18.9353014Z sphinx-rtd-theme 1.0.0 requires docutils<0.18, but you have docutils 0.18.1 which is incompatible.
2023-03-02T12:28:18.9353901Z sphinx-prompt 1.6.0 requires Sphinx<7.0.0,>=6.0.0, but you have sphinx 5.3.0 which is incompatible.
```
