### PR TITLE
Fixed excerpts with logo

### DIFF
--- a/docs/about/contributing/website/publishing-news.rst
+++ b/docs/about/contributing/website/publishing-news.rst
@@ -50,6 +50,12 @@ The content of the file should start like this:
   :category: <Refer to the doco for the category>
   :tags: <Refer to the doco for tags to use (comma separated list)>
   :excerpt: 1
+  :image: 0
+
+  .. image:: /_static/images/logos/product-logo-news.png
+    :alt: DCC-EX News
+    :scale: 40%
+    :class: image-product-logo-float-right
 
   Post title
   ==========
@@ -74,7 +80,7 @@ The `:date:`, `:author:`, `:category:`, and `:tags:` metadata fields must be upd
 
   Give careful consideration to the date of the post compared to your timezone. If you publish the website with a new post dated today, and today for the timezone you are in is ahead of GMT (eg. GMT+10 for Brisbane, Australia where this author is located), the post will not be displayed as it is considered in the future.
   
-  All other metadata/RST directives must remain intact as provided in the template, including the ".. include" lines, `:blogpost:`, and `:excerpt:`.
+  All other metadata/RST directives must remain intact as provided in the template, including the ".. include" lines, `:blogpost:`, `:excerpt:`, `:image:`, and the logo image directive.
 
 Valid categories and tags
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/news/posts/20230309.rst
+++ b/docs/news/posts/20230309.rst
@@ -7,8 +7,12 @@
 :category: News
 :tags: dcc-ex, news
 :excerpt: 1
+:image: 0
 
-|EX-NEWS-LOGO|
+.. image:: /_static/images/logos/product-logo-news.png
+  :alt: DCC-EX News
+  :scale: 40%
+  :class: image-product-logo-float-right
 
 Extra, extra, read all about it! Introducing DCC-EX News!
 =========================================================

--- a/docs/news/posts/20230309a.rst
+++ b/docs/news/posts/20230309a.rst
@@ -7,8 +7,12 @@
 :category: News
 :tags: ex-toolbox
 :excerpt: 1
+:image: 0
 
-|EX-NEWS-LOGO|
+.. image:: /_static/images/logos/product-logo-news.png
+  :alt: DCC-EX News
+  :scale: 40%
+  :class: image-product-logo-float-right
 
 EX-Toolbox released on the Play Store
 =====================================

--- a/docs/news/posts/post-template.txt
+++ b/docs/news/posts/post-template.txt
@@ -6,9 +6,12 @@
 :author: <Your name, either Discord/GitHub username or real name>
 :category: <Refer to the doco for the category>
 :tags: <Refer to the doco for tags to use (comma separated list)>
-:excerpt: 1
+:image: 0
 
-|EX-NEWS-LOGO|
+.. image:: /_static/images/logos/product-logo-news.png
+  :alt: DCC-EX News
+  :scale: 40%
+  :class: image-product-logo-float-right
 
 Post title
 ==========


### PR DESCRIPTION
Can't use logo expansion, must use image directive in news articles, template and articles updated