### PR TITLE
Update Atom URL, fix website test

### DIFF
--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: ScholliYT/Broken-Links-Crawler-Action@v3
         with:
           website_url: 'https://dcc-ex.com/'
-          exclude_url_prefix: 'mailto:'
-          verbose: true
+          exclude_url_prefix: 'mailto:,https://marketplace.visualstudio.com,https://script.google.com,https://www.iascaled.com/store/,https://www.digikey.com'
+          verbose: 'error'
           max_retry_time: 30
           max_retries: 5
           max_depth: 5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,8 @@ DCC-EX Model Railroading
 
     Read the full DCC-EX News feed `here <news.html>`_.
 
+    Subscribe to the DCC-EX News Atom feed using "https://dcc-ex.com/news/atom.xml".
+
   .. grid-item-card:: 
     :columns: 12
     :class-card: sd-shadow-md sd-rounded-3 sd-width-auto

--- a/docs/news/posts/20230309.rst
+++ b/docs/news/posts/20230309.rst
@@ -37,6 +37,6 @@ Here's what's happening at the moment:
 
 If you wish to follow "DCC-EX News", we will have the latest few posts published on the front page of our website, along with the `complete list here <https://dcc-ex.com/news.html>`_.
 
-If you use an RSS/Atom feed reader, you can add "DCC-EX News" by adding our website "https://dcc-ex.com".
+If you use an RSS/Atom feed reader, you can add "DCC-EX News" by the URL "https://dcc-ex.com/news/atom.xml".
 
 We look forward to sharing more news and information with you all!


### PR DESCRIPTION
Updated DCC-EX News Atom feed URL.

Added ignores to the website test for links that are valid but keep failing.