### PR TITLE
Updated doc to  DCC-EX 4.1 and JMRI 5.2 pdf

### DIFF
--- a/docs/reference/downloads/documents.rst
+++ b/docs/reference/downloads/documents.rst
@@ -43,7 +43,7 @@ You can also add user defined ATC Automatic Throttle Control Jython.py scripts t
 .. rst-class:: dcclink
 
 Download DCC-EX Commands.py script (zip) files for JMRI to display DCC-EX Command Summary Lists through the JMRI Script Output Window. 
-   `DCC-EX Commands JMRI Script </_static/documents/DCCEX_Commands_3.1.py.zip>`_
+   `DCC-EX Commands JMRI Script </_static/documents/DCCEX_Commands_4.1.py.zip>`_
 
 .. rst-class:: clearer
 
@@ -61,7 +61,7 @@ You can have the command references for |DCC-EX| shown through the Script Output
    
 .. rst-class:: dcclink
 
-   `DCC-EX + JMRI Custom Buttons SetUp </_static/documents/DCCEX_31_JMRI_Script+Button_Instructions.pdf>`_
+   `DCC-EX + JMRI Custom Buttons SetUp </_static/documents/DCCEX_4.1_JMRI_Script+Button_Instructions.pdf>`_
 
 .. rst-class:: clearer
 
@@ -78,7 +78,7 @@ For a more extensive overview of setting up |EX-CS| with JMRI DecoderPro please 
    
 .. rst-class:: dcclink
 
-   `EX-CommandStation 3.1 & JMRI DecoderPro 2.24 Getting Started Guide.pdf version 1.0 </_static/documents/DCCEX_3.1_and_JMRI_Decoder_Pro_4.24-_Getting_Started_Guide-1.pdf>`_
+   `EX-CommandStation 4.1 & JMRI DecoderPro 5.2 Getting Started Guide.pdf version 4.0 </_static/documents/Updated_DCCEX_4.1_and_JMRI_Decoder_Pro_5.2-_Getting_Started_Guide.pdf>`_
 
 .. rst-class:: clearer
 


### PR DESCRIPTION
Replace the existing DCC-EX 3.1 and JMRI 4.2 documentation and CommandSummary3.1.py.zip file with the newer
DCC-EX 4.1 and JMRI 5.2 pdf documents and new CommandSummary4.1.py.zip  file

I created and updated the JMRI screens and fixed all the broken DCC-EX website and Third Party URL pointers in the .pdf document

But they need to be place in the _static/documents folder before this page gets updated KCS