### PR TITLE
Change development refs to v5

### DIFF
--- a/docs/ex-ioexpander/overview.rst
+++ b/docs/ex-ioexpander/overview.rst
@@ -49,9 +49,7 @@ This page provides the general overview of |EX-IO|, as well as outlining the con
 Software requirements
 =====================
 
-To utilise |EX-IO|, you must be running the latest unreleased Development version of |EX-CS|.
-
-Refer to :ref:`download/ex-commandstation:latest ex-commandstation unreleased development version` on how to obtain this.
+To utilise |EX-IO|, you must be running version 5.0.0 or later of |EX-CS|.
 
 In addition, you will require the |EX-IO| software which can be found here:
 
@@ -59,7 +57,7 @@ In addition, you will require the |EX-IO| software which can be found here:
 
   `EX-IOExpander Github Repository <https://github.com/DCC-EX/EX-IOExpander>`_
 
-It is now possible to install |EX-IO| via |EX-I|, see :ref:`ex-ioexpander/overview:installation via ex-installer`.
+Both of these can be installed via |EX-I|, see :doc:`/ex-installer/installing` and :ref:`ex-ioexpander/overview:installation via ex-installer`.
 
 Hardware requirements
 =====================

--- a/docs/ex-turntable/test-and-tune.rst
+++ b/docs/ex-turntable/test-and-tune.rst
@@ -366,9 +366,7 @@ The rotary encoder software can be downloaded from:
 
   `dcc-ex-rotary-encoder GitHub repository <https://github.com/peteGSX-Projects/dcc-ex-rotary-encoder>`_
 
-To utilise |EX-IO|, you must be running the latest unreleased Development version of |EX-CS|.
-
-Refer to :ref:`download/ex-commandstation:latest ex-commandstation unreleased development version` on how to obtain this.
+To utilise this rotary encoder, you must be running version 5.0.0 or later of |EX-CS|.
 
 Enabling the device driver
 --------------------------

--- a/docs/trackmanager/index.rst
+++ b/docs/trackmanager/index.rst
@@ -49,14 +49,6 @@ No additional external DCC decoders are required for DC (PWM) track assignments,
 
 One key difference to note in comparing DCC vs. DC is that in DCC mode, forward/reverse is determined by the DCC decoder, not the track, whereas in DC mode the direction is dependent upon the track polarity.
 
-.. warning:: 
-
-  This feature is under active development, meaning commands, features, and behaviour may change without notice. While we endeavour to keep these features functional, our development releases are updated regularly and we cannot guarantee there are no bugs that will have unexpected results.
-
-  If using our development release and, especially, the |TM| feature, we highly recommend keeping in touch with conversations and developments via our `Discord server <https://discord.gg/PuPnNMp8Qf>`_.
-
-  You can also use our new GitHub issue templates to report a bug: |githublink-ex-commandstation-button2|
-
 Before you begin
 ----------------
 
@@ -359,12 +351,8 @@ Using the New TrackManager Function commands you can run the any layout as
 
 All done through the free |DCC-EX| TrackManager commands.
 
-How Do I Get On Board with DCC-EX TrackManager ?
-=================================================
-
-To use TrackManager, you will need the current development version of |EX-CS| which you can obtain by following the directions in our :ref:`download/ex-commandstation:latest ex-commandstation unreleased development version` section.
-
-We highly encourage you to join our Discord server to keep up to date on developments. Refer to :ref:`support/contact-us:contact us` for details on how to join.
+EXRAIL examples
+===============
 
 Example of User defined EXRAIL Scripts running on Engine Driver Throttle App (Android):
 ---------------------------------------------------------------------------------------
@@ -436,8 +424,6 @@ Example of User defined EXRAIL Scripts running on Engine Driver Throttle App (An
   :scale: 50%
 
   Track Manager - Engine Driver handoff/set
-
-
 
 EXRAIL Functions Displaying on Smartphone Apps & Universal WiFi Throttles
 -------------------------------------------------------------------------


### PR DESCRIPTION
Change remaining references to the latest development release to 5.0.0 or later instead.