### PR TITLE
Add EX-Installer to IO/TT download pages

### DIFF
--- a/docs/download/ex-ioexpander.rst
+++ b/docs/download/ex-ioexpander.rst
@@ -10,6 +10,42 @@ EX-IOExpander
 
 |EX-IO| is a software based I/O expander using an Arduino microcontroller to expand the I/O pins available for |EX-CS| using both digital and analogue pins.
 
+You can now use |EX-I| to download and install |EX-IO|.
+
+.. note:: 
+   :class: note-float-right
+
+   If you have any difficulties with the automated installer link try these:
+
+      .. rst-class:: dcclink
+
+         `For Windows x64 <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-Win64.exe>`_
+
+      .. rst-class:: dcclink
+
+         `For Windows x32 <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-Win32.exe>`_
+
+         `For MacOS / OSX <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-macOS>`_
+
+      .. rst-class:: dcclink
+
+         `For Linux x64 <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-Linux64>`_
+
+Clicking on the link below will automatically find the correct version of the installer for your Computer and Operating system (Windows, Apple, Linux) and download it.
+
+This downloads a self contained app that can automatically load the software from your computer to your Arduino or other supported board. Click here for :doc:`EX-Installer installation instructions </ex-commandstation/get-started/installer>`.
+
+
+.. raw:: html 
+
+   <p class="dcclink"><a onclick="getNewLink()"><span class="problematic">Automated Installer</span></a></p>
+
+|force-break|
+
+----
+
+If you need to obtain the source code for any reason, it is available on GitHub here:
+
 .. rst-class:: dcclink
 
    `EX-IOExpander Github Repository <https://github.com/DCC-EX/EX-IOExpander>`_

--- a/docs/download/ex-turntable.rst
+++ b/docs/download/ex-turntable.rst
@@ -10,6 +10,42 @@ EX-Turntable
 
 |EX-TT| is a fully integrated turntable controller, using an Arduino microcontroller to drive a stepper controller and motor to spin the turntable bridge.
 
+You can now use |EX-I| to download and install |EX-TT|.
+
+.. note:: 
+   :class: note-float-right
+
+   If you have any difficulties with the automated installer link try these:
+
+      .. rst-class:: dcclink
+
+         `For Windows x64 <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-Win64.exe>`_
+
+      .. rst-class:: dcclink
+
+         `For Windows x32 <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-Win32.exe>`_
+
+         `For MacOS / OSX <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-macOS>`_
+
+      .. rst-class:: dcclink
+
+         `For Linux x64 <https://github.com/DCC-EX/EX-Installer/raw/main/dist/EX-Installer-Linux64>`_
+
+Clicking on the link below will automatically find the correct version of the installer for your Computer and Operating system (Windows, Apple, Linux) and download it.
+
+This downloads a self contained app that can automatically load the software from your computer to your Arduino or other supported board. Click here for :doc:`EX-Installer installation instructions </ex-commandstation/get-started/installer>`.
+
+
+.. raw:: html 
+
+   <p class="dcclink"><a onclick="getNewLink()"><span class="problematic">Automated Installer</span></a></p>
+
+|force-break|
+
+----
+
+If you need to obtain the source code for any reason, it is available on GitHub here:
+
 .. rst-class:: dcclink
 
   `EX-Turntable Github Repository <https://github.com/DCC-EX/EX-Turntable/releases>`_


### PR DESCRIPTION
Update EX-IOExpander and EX-Turntable download pages to include EX-Installer.