### PR TITLE
Updated info for Train Throttle software based throttle

### DIFF
--- a/docs/throttles/software/index.rst
+++ b/docs/throttles/software/index.rst
@@ -26,7 +26,7 @@ Android (Phones and Tablets)
 Apple iOS (Phones and Tablets)
 ------------------------------
 
-- :doc:`ThrottleCard (iOS) <throttlecard>`
+- :doc:`Train Throttle (iOS) <train-throttle>`
 - :doc:`Locontrol (iOS) <locontrol>` *- Requires JMRI*
 - :doc:`DigiTrainsPro (Android, iOS, Windows) <digitrainspro>` *- Requires JMRI*
 - :doc:`WiThrottle (iOS)<withrottle>`
@@ -39,7 +39,7 @@ Personal Computers
 
 - :doc:`EX-WebThrottle </ex-webthrottle/index>`  *(Web Browser)*
 - :doc:`JMRI (Windows, iOS, Linux) <jmri>`
-- :doc:`Train Throttle (Windows) <train-throttle>`
+- :doc:`Train Throttle (Mac, Windows) <train-throttle>` *- Requires WiThrottle server*
 - :doc:`DigiTrainsPro (Android, iOS, Windows) <digitrainspro>` *- Requires JMRI*
 - :doc:`Railroad Automation <railroad-automation>` *- Requires IoTT Red Hat*
 - :doc:`ThrottleCard (M1 Mac) <throttlecard>` *- Requires WiThrottle server*
@@ -62,7 +62,7 @@ Note: The Android throttle apps listed above can be made to made to run on Windo
     SRCP Client (iOS) <srcpclient>
     Train Driver (iOS) <train-driver>
     ThrottleCard (iOS) <throttlecard>
-    Train Throttle (Windows) <train-throttle>
+    Train Throttle (Windows, Mac, iOS) <train-throttle>
     Android Apps on Windows <android-apps-on-windows>
     Railroad Automation (Windows) <railroad-automation>
  

--- a/docs/throttles/software/train-throttle.rst
+++ b/docs/throttles/software/train-throttle.rst
@@ -12,6 +12,16 @@ Train Throttle
    :scale: 30%
    :align: left
 
-Train Throttle is a fully featured client for the JMRI WiThrottle server, which allows you to control your DCC equipped model trains. You can control a single engine or consist, create consists, set turnouts, toggle routes, and more.
+.. image:: /_static/images/throttles/icon_ios.png
+   :alt: iOS Logo
+   :scale: 30%
+   :align: left
 
+Train Throttle is a fully featured client for the JMRI WiThrottle server, which allows you to control your DCC equipped model trains.
+
+Please see the website for the full feature list.
+
+https://drewhoffman.net/trainthrottle/ |EXTERNAL-LINK|
+https://apps.apple.com/us/app/train-throttle/id1662181863 |EXTERNAL-LINK|
 https://apps.microsoft.com/detail/9NBLGGH4VF5J?hl=en-US&gl=US |EXTERNAL-LINK|
+

--- a/docs/throttles/throttle_table.rst
+++ b/docs/throttles/throttle_table.rst
@@ -194,16 +194,16 @@
       -  
 
     * -  :doc:`Train Throttle <software/train-throttle>`
-      -  Free
+      -  Free / Paid
       -  WiFi
       -  WiT
       -  App
       -  
       -  
       -  
-      -  
       -  X
-      -  
+      -  X
+      -  X
       -  
       -  
 


### PR DESCRIPTION
I just found that my app Train Throttle is listed in the docs :)

I've updated the info.

Also, ThrottleCard is no longer listed twice in the index.rst.