### PR TITLE
Turnout_ID consistency

### DIFF
--- a/docs/exrail/exrail-command-reference.rst
+++ b/docs/exrail/exrail-command-reference.rst
@@ -1401,13 +1401,13 @@ All the below turnout/point definitions will define turnouts/points that are adv
 
 .. _turnout:
 
-``TURNOUT( id, addr, sub_addr [, "description"]|HIDDEN )`` - Define a DCC accessory turnout/point
+``TURNOUT( turnout_id, addr, sub_addr [, "description"]|HIDDEN )`` - Define a DCC accessory turnout/point
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Define a DCC accessory turnout/point. Note that DCC linear addresses are not supported, and must be converted to address/subaddress in order to be defined. Refer to the :ref:`reference/downloads/documents:stationary decoder address table (xlsx spreadsheet)` for help on these conversions. (or see TURNOUTL below).
 
 *Parameters:* |BR|
-|_| > **id** - identifier of the Turnout/Point |BR|
+|_| > **turnout_id** - identifier of the Turnout/Point |BR|
 |_| > **addr** - ranges from 0 to 511 |BR|
 |_| > **subaddr** - ranges from 0 to 3 |BR|
 |_| > **description** - The description that will be assigned to the turnout/point, or |BR|
@@ -1418,7 +1418,7 @@ Define a DCC accessory turnout/point. Note that DCC linear addresses are not sup
 
 .. _turnoutl:
 
-``TURNOUTL( id, addr [, "description"]|HIDDEN )`` - Define a DCC accessory turnout/point
+``TURNOUTL( turnout_id, addr [, "description"]|HIDDEN )`` - Define a DCC accessory turnout/point
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Define a DCC accessory turnout/point.  This command will convert a linear address to the address/subaddress format using the TURNOUT command above.
@@ -1429,13 +1429,13 @@ Note when providing the name of the profile the profile names are case sensitive
 
 .. _pin_turnout:
 
-``PIN_TURNOUT( id, pin [, "description"]|HIDDEN )`` - Define a pin operated turnout
+``PIN_TURNOUT( turnout_id, pin [, "description"]|HIDDEN )`` - Define a pin operated turnout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Define a pin operated turnout. When sending a CLOSE command, the pin will be HIGH, and a THROW command will set the pin LOW.
 
 *Parameters:* |BR|
-|_| > **id** - unique Id for the servo |BR|
+|_| > **turnout_id** - unique Id for the turnout/point servo |BR|
 |_| > **pin** - vpin to which the servo is attached |BR|
 |_| > **description** - The description that will be assigned to the turnout/point, or |BR|
 |_| > *HIDDEN* - keyword - if used instead of the "description" the Turnout/point will not appear in the lists sent to throttle/controllers |BR|
@@ -1445,13 +1445,13 @@ Define a pin operated turnout. When sending a CLOSE command, the pin will be HIG
 
 .. _servo_turnout:
 
-``SERVO_TURNOUT( id, pin, active_angle, inactive_angle, profile [, "description"]|HIDDEN )`` - Define a servo turnout/point 
+``SERVO_TURNOUT( turnout_id, pin, active_angle, inactive_angle, profile [, "description"]|HIDDEN )`` - Define a servo turnout/point 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Define a servo turnout/point. "active_angle" is for THROW, "inactive_angle" is for CLOSE, and profile is one of Instant, Fast, Medium, Slow or Bounce (although clearly we don't recommend Bounce for turnouts/points!). 
 
 *Parameters:* |BR|
-|_| > **id** - unique Id for the servo |BR|
+|_| > **turnout_id** - unique Id for the turnout/point servo |BR|
 |_| > **pin** - vpin to which the servo is attached |BR|
 |_| > **active_angle** - the PWM value corresponding to the servo position for THROWN state, normally in the range 102 to 490 |BR|
 |_| > **inactive_angle** - the PWM value corresponding to the servo position for CLOSED state, normally in the range 102 to 490 |BR|
@@ -1471,7 +1471,7 @@ Refer to :doc:`/reference/hardware/servo-module` for more information.
 
 .. _virtual_turnout:
 
-``VIRTUAL_TURNOUT( id [, "description"]|HIDDEN )`` - Define a virtual turnout, which is backed by another automation sequence
+``VIRTUAL_TURNOUT( turnout_id [, "description"]|HIDDEN )`` - Define a virtual turnout, which is backed by another automation sequence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Define a virtual turnout, which is backed by another automation sequence. 


### PR DESCRIPTION
Made the ID parameter consistently 'turnout_id' in the turnout/point definition section