### PR TITLE
Fix EX-IOExpander Supported Devices sidebar

### DIFF
--- a/docs/ex-ioexpander/supported-devices.rst
+++ b/docs/ex-ioexpander/supported-devices.rst
@@ -10,7 +10,7 @@ Supported Devices
 |SUITABLE| |tinkerer| |engineer| |support-button| |githublink-ex-ioexpander-button-small|
 
 .. sidebar:: 
-   :class: sidebar-on-this-page
+  :class: sidebar-on-this-page
   
   .. contents:: On this page
     :depth: 2


### PR DESCRIPTION
`:class: sidebar-on-this-page` is showing on the web and the sidebar has no shadow.

https://dcc-ex.com/ex-ioexpander/supported-devices.html#gsc.tab=0