### PR TITLE
CabForward

### DIFF
--- a/docs/throttles/index.rst
+++ b/docs/throttles/index.rst
@@ -64,6 +64,7 @@ Apple iOS (Phones and Tablets)
 - :doc:`WiThrottle (iOS) <software/withrottle>`
 - :doc:`DCC Commander (iOS) <software/dcc-commander>`
 - :doc:`Signal Cab (iOS) <software/signal-cab>`
+- :doc:`CabForward (iOS) <software/cabforward>`
 
 Dedicated Hardware
 ------------------
@@ -90,6 +91,7 @@ Personal Computers
 - :doc:`Railroad Automation <software/railroad-automation>` *- Requires IoTT Red Hat*
 - :doc:`Train Throttle (Windows, iOS) <software/train-throttle>`
 - :doc:`ThrottleCard (MacOS, iOS) <software/throttlecard>` *- Requires WiThrottle server*
+- :doc:`CabForward (MacOS) <software/cabforward>`
 
 Note: The Android throttle apps listed above can be made to made to run on Windows PCs. See :doc:`Running Android apps on Microsoft Windows <software/android-apps-on-windows>`.
 
@@ -125,6 +127,7 @@ DCC-EX (DCC-EX Native Commands)
 - :doc:`DCC Commander (iOS) <software/dcc-commander>`
 - :doc:`Signal Cab (iOS) <software/signal-cab>`
 - :doc:`DCC-EX Simple Throttler (Physical) <hardware/simple-throttle>`
+- :doc:`CabForward (iOS) <software/cabforward>`
 - :doc:`DccExController (Physical DIY) <hardware/dccexcontroller>`  - Support Discontinued |BR| |BR|
 - See also :doc:`DCC-EX Native command library - DCCEXProtocol </throttles/native-protocol-library>`
 

--- a/docs/throttles/software/cabforward.rst
+++ b/docs/throttles/software/cabforward.rst
@@ -1,0 +1,120 @@
+.. include:: /include/include.rst
+.. include:: /include/include-l2.rst
+.. include:: /include/include-throttles.rst
+
+**********
+CabForward
+**********
+
+|SUITABLE| |conductor| |tinkerer| |engineer| |support-button|
+
+.. sidebar::
+   :class: sidebar-on-this-page
+
+   .. contents:: On this page
+      :depth: 2
+      :local:
+
+.. image:: /_static/images/throttles/icon_ios.png
+   :alt: iOS Logo
+   :scale: 30%
+   :align: left
+
+CabForward is a fully native iPhone and iPad app that aims to be a complete,
+delightful control surface for your model railroad: throttles, roster, EX-RAIL
+routes & automations, operating sessions, accessories, command-station
+management, and decoder programming, all wrapped in a polished, fully themeable
+interface. Because it speaks the |DCC-EX Native Commands| directly, it is fast
+and can take advantage of features specific to the |EX-CS|.
+
+Please visit the website: https://cabforwarddcc.com |EXTERNAL-LINK|
+
+You can find it in the App Store: `CabForward
+<https://apps.apple.com/us/app/cabforward/id6777802417>`_ |EXTERNAL-LINK|
+
+For more information about these protocols, see :doc:`WiThrottle Server, Web
+Server, DCC-EX Native Commands Explained </throttles/protocols>`
+
+.. _cabforward-features:
+
+Features
+=========
+
+* Multi-train throttle deck with per-locomotive control styles (slider or rotary),
+  a full function grid, stop and emergency stop
+* Roster with customizable photos, functions, on-device AI
+  background removal, consist building, and a catalog for non-powered rolling
+  stock
+* Automatically generated switching games and operating
+  sessions built from your layout profile and roster, plus a custom scenario
+  builder
+* Author, run, and export EX-RAIL routes & automations as a compliant
+  ``myAutomation.h``, and start or kill routines already flashed on the command
+  station
+* Accessory control for turnouts, signals, and outputs
+* Command-station management: auto-discovery, power, track manager, power
+  districts, fast clock, WiFi configuration, and a step-by-step setup guide
+* Locomotive programming: read and write the loco address, CV byte and bit
+  read/write on the programming track, and program-on-main (POM) writes
+* A large library of railroad-inspired themes, with optional per-locomotive
+  liveries
+* iCloud sync, an Apple Watch companion, a Home Screen widget, Siri & Shortcuts
+  intents, and physical game-controller support
+
+.. _cabforward-screenshots:
+
+Screenshots
+============
+
+.. image:: /_static/images/throttles/cabforward1.jpg
+   :alt: CabForward Train Controls
+   :scale: 50%
+
+.. image:: /_static/images/throttles/cabforward2.jpg
+   :alt: CabForward Roster
+   :scale: 50%
+
+.. image:: /_static/images/throttles/cabforward3.jpg
+   :alt: CabForward Operations
+   :scale: 50%
+
+.. image:: /_static/images/throttles/cabforward4.jpg
+   :alt: CabForward Routes & Automations
+   :scale: 50%
+
+.. image:: /_static/images/throttles/cabforward5.jpg
+   :alt: CabForward Command Station
+   :scale: 50%
+
+.. image:: /_static/images/throttles/cabforward6.jpg
+   :alt: CabForward Locomotive Programming
+   :scale: 50%
+
+.. _cabforward-requirements:
+
+Requirements
+=============
+
+* A WiFi-enabled |EX-CS| (see :doc:`Wifi Setup </ex-commandstation/diy/wifi-setup>`)
+* An iPhone, iPad, or Apple Silicon Mac
+* Both devices on the same WiFi network, or the device joined to the command
+  station's own access point
+
+.. _cabforward-operation:
+
+Operation
+==========
+
+* Make sure your |EX-CS| has WiFi enabled, as described in the :doc:`Wifi Setup
+  </ex-commandstation/diy/wifi-setup>` section.
+* Connect your iPhone or iPad to the same network as the command station, or to
+  the command station's own access point.
+* Open CabForward. It automatically discovers the command station on the
+  network; tap it to connect, or enter the host/IP address and port (default
+  2560) manually.
+
+CabForward is free to drive a single locomotive, control accessories, and manage
+the command station. CabForward Pro unlocks the roster, operating sessions,
+routes & automations, locomotive programming, multiple trains and consists,
+themes, iCloud sync, and more, and is offered as monthly and annual
+subscriptions or a one-time lifetime purchase.

--- a/docs/throttles/throttle_table.rst
+++ b/docs/throttles/throttle_table.rst
@@ -291,6 +291,20 @@
       -  
       -  
 
+ * -  :doc:`CabForward <software/cabforward>`
+      -  Free / Paid
+      -  WiFi
+      -  Native
+      -  App
+      -  
+      -  
+      -  
+      -  X
+      -  
+      -  
+      -  
+      -  X
+
     * -  :doc:`DccExController <hardware/dccexcontroller>`
       -  Free
       -  WiFi


### PR DESCRIPTION
add the iOS/MacOS app CabForward to the list of available throttles on the DCC-EX Website