### PR TITLE
docs: add LocoLink to software throttles

### DIFF
--- a/docs/throttles/software/index.rst
+++ b/docs/throttles/software/index.rst
@@ -31,6 +31,7 @@ Apple iOS (Phones and Tablets)
 
 - :doc:`DigiTrainsPro (Android, iOS, Windows) <digitrainspro>` *- Requires JMRI*
 - :doc:`ThrottleCard (iOS) <throttlecard>`
+- :doc:`LocoLink (iOS and iPadOS) <locolink>`
 - :doc:`Locontrol (iOS) <locontrol>` *- Requires JMRI*
 - :doc:`SRCP Client (iOS) <srcpclient>`
 - :doc:`Train Driver (iOS) <train-driver>`
@@ -47,6 +48,7 @@ Personal Computers
 - :doc:`EX-WebThrottle (Web Browser) </ex-webthrottle/index>`  *recommended*
 - :doc:`JMRI (Windows, iOS, Linux) <jmri>`  *recommended*
 - :doc:`DigiTrainsPro (Android, iOS, Windows) <digitrainspro>` *- Requires JMRI*
+- :doc:`LocoLink (Windows and Mac) <locolink>`
 - :doc:`Railroad Automation <railroad-automation>` *- Requires IoTT Red Hat*
 - :doc:`ThrottleCard (M1 Mac) <throttlecard>` *- Requires WiThrottle server*
 - :doc:`Train Throttle (Mac, Windows) <train-throttle>` *- Requires WiThrottle server*
@@ -68,6 +70,7 @@ Note: The Android throttle apps listed above can be made to made to run on Windo
     DCC++ Throttle (android) <dccpp-throttle>
     DigiTrainsPro (Android, iOS, Windows) <digitrainspro>
     Locontrol (iOS) <locontrol>
+    LocoLink (Windows, Mac, iOS and iPadOS) <locolink>
     Railroad Automation (Windows) <railroad-automation>
     RtDrive DCC++ (Android) <rtdrive-dccpp>
     SRCP Client (iOS) <srcpclient>
@@ -78,4 +81,3 @@ Note: The Android throttle apps listed above can be made to made to run on Windo
     Signal Cab (iOS) <signal-cab>
     DCC Commander (iOS) <dcc-commander>
     Android Apps on Windows <android-apps-on-windows>
- 

--- a/docs/throttles/software/locolink.rst
+++ b/docs/throttles/software/locolink.rst
@@ -1,0 +1,50 @@
+.. include:: /include/include.rst
+.. include:: /include/include-l2.rst
+.. include:: /include/include-throttles.rst
+********
+LocoLink
+********
+
+|SUITABLE| |conductor| |tinkerer| |engineer| |support-button|
+
+.. image:: /_static/images/throttles/icon_windows.png
+   :alt: Windows Logo
+   :scale: 30%
+   :align: left
+
+.. image:: /_static/images/throttles/icon_ios.png
+   :alt: Apple iOS Logo
+   :scale: 30%
+   :align: left
+
+LocoLink is model railway control software for Windows, Mac, iPhone and iPad.
+It connects directly to |EX-CS| using |DCC-EX Native Commands| over TCP on
+WiFi or Ethernet. Windows and Mac can also connect directly over USB serial.
+|JMRI| is not required for these direct connection routes.
+
+`LocoLink DCC-EX guide <https://locolink.io/dcc-ex-throttle-app>`_ |EXTERNAL-LINK|
+
+`Download LocoLink <https://locolink.io/download>`_ |EXTERNAL-LINK|
+
+`LocoLink on the Apple App Store <https://apps.apple.com/us/app/locolink/id6760320854>`_ |EXTERNAL-LINK|
+
+Features
+========
+
+* Loco speed, direction, emergency stop and function control
+* Turnout/point control and routes
+* DCC decoder CV programming
+* DCC-EX roster and sensor events
+* Visual track plan, feedback, blocks and automation
+* DCC-EX diagnostics for EXRAIL, HAL/VPIN and TrackManager data
+
+Requirements
+============
+
+* Windows 10/11, Mac, iPhone or iPad
+* |EX-CS| with USB, WiFi or Ethernet configured for the selected device
+* iPhone and iPad use the network connection; USB serial is for Windows and Mac
+
+LocoLink is independent software by Westerman and is not an official DCC-EX
+product. Some advanced LocoLink features require a paid plan after the 30-day
+Pro trial.


### PR DESCRIPTION
This adds LocoLink to the DCC-EX software-throttle directory for Windows, Mac, iPhone and iPad. LocoLink connects directly to EX-CommandStation with DCC-EX native commands over TCP; Windows and Mac can also use USB serial. The new page describes the supported platforms, connection routes and main control features, and clearly states that LocoLink is independent software rather than an official DCC-EX product.

Validation: all 428 documentation sources passed a Sphinx 8.1.3 build with warnings treated as errors. The local macOS run disabled only the spelling extension because its native enchant library was unavailable. Product and platform details are documented at https://locolink.io/dcc-ex-throttle-app.