### PR TITLE
docs: add EXRAIL resource usage guide

### DIFF
--- a/docs/exrail/index.rst
+++ b/docs/exrail/index.rst
@@ -28,6 +28,7 @@ Click 'Next' to explore the possibilities of |EX-R|.
     getting-started
     examples
     tips
+    resource-usage
     cookbooks/index
     exrail-command-reference
     about

--- a/docs/exrail/resource-usage.rst
+++ b/docs/exrail/resource-usage.rst
@@ -1,5 +1,5 @@
 EXRAIL compiler and resource usage
-=================================
+==================================
 
 EXRAIL expands ``myAutomation.h`` into a byte-coded route table and lookup tables during firmware compilation. The route table is stored in flash. At startup, routes and event handlers are indexed in RAM, and each active sequence has an ``RMFT2`` task object.
 

--- a/docs/exrail/resource-usage.rst
+++ b/docs/exrail/resource-usage.rst
@@ -1,0 +1,21 @@
+EXRAIL compiler and resource usage
+=================================
+
+EXRAIL expands ``myAutomation.h`` into a byte-coded route table and lookup tables during firmware compilation. The route table is stored in flash. At startup, routes and event handlers are indexed in RAM, and each active sequence has an ``RMFT2`` task object.
+
+Task lifetime and recycling
+---------------------------
+
+Running sequences are linked in a task ring. When a task reaches ``DONE`` or is killed, its destructor releases the task object so a later sequence can reuse that heap allocation. Concurrent sequences increase peak RAM use; completed tasks can be recycled. Each task stores program-counter, delay, locomotive, event, pause, and call-stack state. The current upstream implementation sets the call-stack depth to 4.
+
+Runtime resource use
+--------------------
+
+Startup allocates RAM-backed lookup arrays for routes and event handlers including ``ONTHROW``, ``ONCLOSE``, ``ONACTIVATE``, ``ONCHANGE``, ``ONTIME``, and overload/block handlers when used. Signals and route-state features add further tables. The exact cost depends on the target board, definitions, optional features, and simultaneous tasks. There is no portable maximum-lines limit: available flash and free heap are the practical limits.
+
+Compile-time checks
+-------------------
+
+The assertion pass over ``myAutomation.h`` checks sequence references and duplicate route/automation/sequence IDs; flag IDs 0--255; speed values 0--127; ``SPEED_REL`` 1--500 percent; valid signal addresses; and reserved motor-shield/critical pins used by ``SET``, ``RESET``, ``BLINK``, and signal macros. These checks do not measure runtime capacity: compile success and sufficient free RAM are separate checks.
+
+When a script grows, inspect compiler flash/RAM output and test the largest expected number of simultaneous automations and event handlers. Let finished sequences reach ``DONE``, avoid unnecessary concurrent tasks, remove unused event handlers/features, and keep ``CALL`` nesting within 4. These details are based on upstream ``EXRAIL2.h``, ``EXRAIL2.cpp``, and ``EXRAILAsserts.h`` and may change with firmware revisions.


### PR DESCRIPTION
## Automatic issue closing

Fixes #1187

Addresses documentation issue [#1187](https://github.com/DCC-EX/dcc-ex.github.io/issues/1187).

Supersedes the closed fork-only duplicate [BanjoR/dcc-ex.github.io#1](https://github.com/BanjoR/dcc-ex.github.io/pull/1).

## Bounded scope

- Adds `docs/exrail/resource-usage.rst` covering EXRAIL task recycling, flash/RAM allocation, compile-time checks, supported limits, and practical resource checks.
- Adds one `resource-usage` entry to the EXRAIL toctree in `docs/exrail/index.rst`.
- Excludes firmware/source changes, generated files, and unrelated documentation.

The content is based on the upstream [EXRAIL2.h](https://github.com/DCC-EX/CommandStation-EX/blob/master/EXRAIL2.h), [EXRAIL2.cpp](https://github.com/DCC-EX/CommandStation-EX/blob/master/EXRAIL2.cpp), and [EXRAILAsserts.h](https://github.com/DCC-EX/CommandStation-EX/blob/master/EXRAILAsserts.h).

## Validation evidence

- PASS — clean task-owned checkout on `codex/docs-exrail-compiler-resource`; `upstream/sphinx` is the merge base; exact diff is two allowed paths, 22 additions, 0 deletions.
- PASS — `git diff --check`.
- PASS — focused Docutils parse of `docs/exrail/resource-usage.rst` with bundled Python 3.12.13.
- PASS — toctree migration check: `resource-usage` is present and resolves to the added page.
- PASS — no generated or unrelated files in `git status`.
- PASS — title underline correction in [22ce20e](https://github.com/BanjoR/dcc-ex.github.io/commit/22ce20e310663605534e08ba8679ba5be30cd625); the prior focused warning was `Title underline too short`, and the rerun passes.

## Unavailable checks

- PASS - full Sphinx HTML render and whole-site build completed with the pinned `requirements.txt` dependencies using `python -m sphinx -M html docs docs\_build\audit -W --keep-going`; all 428 sources were read and HTML output was generated successfully.
- NOT RUN — no repository-specific executable test suite was discovered for this documentation-only change.
- CI — the current-head [Docs workflow run](https://github.com/DCC-EX/dcc-ex.github.io/actions/runs/31950139510) is completed with `action_required`; GitHub reports no completed PR checks for the current head. Maintainers should rerun CI in an environment with the requirements installed.

This pull request is ready for maintainer review.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `22ce20e310663605534e08ba8679ba5be30cd625`; no hosted code-test result is claimed. Local validation above is the available evidence.
